### PR TITLE
ci: publish CGPs as GitHub releases instead of artifacts

### DIFF
--- a/.github/workflows/update-libs.yml
+++ b/.github/workflows/update-libs.yml
@@ -12,7 +12,7 @@ permissions:
   contents: write
 
 jobs:
-  update-libs:
+  release:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -31,54 +31,19 @@ jobs:
           cache-disabled: true
           add-job-summary: 'never'
 
+      - name: Compute release tag
+        id: tag
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
+        run: echo "name=build-$(date -u +%Y-%m-%d)-${RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+
       - name: Run update-libs script
         env:
-          REF: ${{ github.event.inputs.ref }}
+          REF: ${{ inputs.ref }}
         run: ./scripts/update-libs.sh --ref "$REF"
 
-      - name: Upload Beepy CGP
-        uses: actions/upload-artifact@v4
-        with:
-          name: beepy
-          path: Beepy/build/plugin/*.cgp
-          if-no-files-found: error
-
-      - name: Upload apk-viewer CGP
-        uses: actions/upload-artifact@v4
-        with:
-          name: apk-viewer
-          path: apk-viewer/build/plugin/*.cgp
-          if-no-files-found: error
-
-      - name: Upload markdown-preview CGP
-        uses: actions/upload-artifact@v4
-        with:
-          name: markdown-preview
-          path: markdown-preview/build/plugin/*.cgp
-          if-no-files-found: error
-
-      - name: Upload keystore-generator CGP
-        uses: actions/upload-artifact@v4
-        with:
-          name: keystore-generator
-          path: keystore-generator/build/plugin/*.cgp
-          if-no-files-found: error
-
-      - name: Upload snippets CGP
-        uses: actions/upload-artifact@v4
-        with:
-          name: snippets
-          path: snippets/build/plugin/*.cgp
-          if-no-files-found: error
-
-      - name: Upload ndk-installer CGP
-        uses: actions/upload-artifact@v4
-        with:
-          name: ndk-installer
-          path: ndk-installer-plugin/build/plugin/*.cgp
-          if-no-files-found: error
-
       - name: Commit updated jars
+        id: commit
         run: |
           sha=$(git -C .cache/CodeOnTheGo rev-parse --short HEAD)
           git config user.name "ADFA"
@@ -86,7 +51,18 @@ jobs:
           git add libs/
           if git diff --cached --quiet; then
             echo "No changes to libs/ — nothing to commit."
-            exit 0
+          else
+            git commit -m "chore: update libs from CodeOnTheGo@${sha}"
+            git push
           fi
-          git commit -m "chore: update libs from CodeOnTheGo@${sha}"
-          git push
+          echo "codeonthego_sha=${sha}" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.name }}
+          target_commitish: ${{ steps.commit.outputs.head_sha }}
+          body: Built against CodeOnTheGo@${{ steps.commit.outputs.codeonthego_sha }}.
+          fail_on_unmatched_files: true
+          files: '*/build/plugin/*.cgp'

--- a/scripts/update-libs.sh
+++ b/scripts/update-libs.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 
 REPO_URL="https://github.com/appdevforall/CodeOnTheGo.git"
 DEFAULT_REF="stage"
+PLUGIN_BUILDER_ID="com.itsaky.androidide.plugins.build"
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 LIBS_DIR="$REPO_ROOT/libs"
@@ -108,15 +109,28 @@ echo "Updated libs/ from CodeOnTheGo@$CODEONTHEGO_SHA"
 printf "  %-20s %s\n" "plugin-api.jar"    "$(du -h "$LIBS_DIR/plugin-api.jar" | cut -f1)"
 printf "  %-20s %s\n" "gradle-plugin.jar" "$(du -h "$LIBS_DIR/gradle-plugin.jar" | cut -f1)"
 
-PLUGINS=(Beepy apk-viewer markdown-preview keystore-generator snippets ndk-installer-plugin)
+PLUGINS=()
+for build_file in "$REPO_ROOT"/*/build.gradle.kts; do
+    [ -f "$build_file" ] || continue
+    if grep -qF "$PLUGIN_BUILDER_ID" "$build_file"; then
+        PLUGINS+=("$(basename "$(dirname "$build_file")")")
+    fi
+done
+
+if [ "${#PLUGINS[@]}" -eq 0 ]; then
+    echo "Error: no example plugins discovered (looked for sibling dirs whose build.gradle.kts applies $PLUGIN_BUILDER_ID)." >&2
+    exit 1
+fi
+
 echo ""
+echo "Discovered example plugins: ${PLUGINS[*]}"
 echo "Building all example plugins against the refreshed libs..."
 for plugin in "${PLUGINS[@]}"; do
     echo ""
     echo "→ $plugin"
     (
         cd "$REPO_ROOT/$plugin"
-        if [[ "$plugin" == "ndk-installer-plugin" ]]; then
+        if grep -q 'downloadAssets' build.gradle.kts; then
             ./gradlew --console=plain downloadAssets
         fi
         ./gradlew --console=plain assemblePlugin


### PR DESCRIPTION
Actions/upload-artifact expires links after the retention window and renames .cgp to .zip on download. Switch to action-gh-release so plugin downloads stay available indefinitely with their real filenames. Tags are auto-generated as build-YYYY-MM-DD-<run_number>, so each run produces a unique release without manual version bumps.

Also auto-discover plugins by grep'ing build.gradle.kts for the plugin-builder ID, and replace the per-plugin upload list with a
*/build/plugin/*.cgp glob, so adding a new plugin needs no edits to either the script or the workflow.