### PR TITLE
  Redesign markdown-preview, fix button contrast across plugins

### DIFF
--- a/.github/workflows/build-plugins.yml
+++ b/.github/workflows/build-plugins.yml
@@ -1,0 +1,74 @@
+name: Build plugin artifacts
+
+# Builds every example plugin's .cgp and exposes them as downloadable
+# workflow artifacts. Unlike "Update libs from CodeOnTheGo", this never
+# commits refreshed libs, never publishes a GitHub release, and never
+# deploys to the website — it only produces artifacts you can download
+# from the run summary.
+
+on:
+  workflow_dispatch:
+    inputs:
+      codeonthego_ref:
+        description: CodeOnTheGo branch or tag to build the libs against
+        required: false
+        default: stage
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout plugin-examples
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-disabled: true
+          add-job-summary: 'never'
+
+      - name: Build libs and plugins
+        env:
+          CODEONTHEGO_REF: ${{ github.event.inputs.codeonthego_ref }}
+        run: ./scripts/update-libs.sh --ref "$CODEONTHEGO_REF"
+
+      - name: Stage .cgp files with website filenames
+        run: |
+          mkdir -p deploy-staging
+          declare -A MAP=(
+            ["apk-viewer"]="apk-analyzer.cgp"
+            ["Beepy"]="beepy.cgp"
+            ["keystore-generator"]="keystore-generator.cgp"
+            ["markdown-preview"]="markdown-previewer.cgp"
+            ["ndk-installer-plugin"]="ndk-installer.cgp"
+            ["random-xkcd"]="random-xkcd.cgp"
+            ["snippets"]="snippets.cgp"
+          )
+          for module in "${!MAP[@]}"; do
+            src=$(ls "${module}/build/plugin/"*.cgp 2>/dev/null | head -n1)
+            if [ -z "$src" ]; then
+              echo "ERROR: no .cgp found under ${module}/build/plugin/"
+              exit 1
+            fi
+            cp "$src" "deploy-staging/${MAP[$module]}"
+            echo "Staged $src -> deploy-staging/${MAP[$module]}"
+          done
+          ls -la deploy-staging/
+
+      - name: Upload .cgp artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugins-cgp
+          path: deploy-staging/*.cgp
+          retention-days: 7
+          if-no-files-found: error

--- a/markdown-preview/src/main/AndroidManifest.xml
+++ b/markdown-preview/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <application
         android:label="Markdown Previewer"
-        android:theme="@style/Theme.MarkdownPreviewer">
+        android:theme="@style/PluginTheme">
 
         <!-- Plugin metadata -->
         <meta-data

--- a/markdown-preview/src/main/kotlin/com/codeonthego/markdownpreviewer/MarkdownPreviewerPlugin.kt
+++ b/markdown-preview/src/main/kotlin/com/codeonthego/markdownpreviewer/MarkdownPreviewerPlugin.kt
@@ -11,6 +11,7 @@ import com.itsaky.androidide.plugins.extensions.NavigationItem
 import com.itsaky.androidide.plugins.extensions.ContextMenuContext
 import com.itsaky.androidide.plugins.services.IdeEditorTabService
 import com.codeonthego.markdownpreviewer.fragments.MarkdownPreviewFragment
+import com.codeonthego.markdownpreviewer.viewmodel.MarkdownPreviewViewModel
 import java.io.File
 
 class MarkdownPreviewerPlugin : IPlugin, UIExtension, EditorTabExtension {
@@ -56,6 +57,9 @@ class MarkdownPreviewerPlugin : IPlugin, UIExtension, EditorTabExtension {
 
     override fun dispose() {
         context.logger.info("MarkdownPreviewerPlugin: Disposing plugin")
+        PreviewState.consumePendingFile()
+        PreviewState.consumePendingUri()
+        MarkdownPreviewViewModel.reset()
     }
 
     // UIExtension - No main menu items (accessed via sidebar/context menu)
@@ -94,7 +98,7 @@ class MarkdownPreviewerPlugin : IPlugin, UIExtension, EditorTabExtension {
             NavigationItem(
                 id = "markdown_preview_sidebar",
                 title = "Preview",
-                icon = android.R.drawable.ic_menu_gallery,
+                icon = R.drawable.ic_preview,
                 isEnabled = true,
                 isVisible = true,
                 group = "tools",
@@ -113,7 +117,7 @@ class MarkdownPreviewerPlugin : IPlugin, UIExtension, EditorTabExtension {
             EditorTabItem(
                 id = "markdown_preview_main_tab",
                 title = "Preview",
-                icon = android.R.drawable.ic_menu_gallery,
+                icon = R.drawable.ic_preview,
                 fragmentFactory = {
                     context.logger.debug("Creating MarkdownPreviewFragment")
                     MarkdownPreviewFragment()
@@ -137,6 +141,11 @@ class MarkdownPreviewerPlugin : IPlugin, UIExtension, EditorTabExtension {
 
     override fun onEditorTabClosed(tabId: String) {
         context.logger.info("Editor tab closed: $tabId")
+        if (tabId == "markdown_preview_main_tab") {
+            PreviewState.consumePendingFile()
+            PreviewState.consumePendingUri()
+            MarkdownPreviewViewModel.reset()
+        }
     }
 
     override fun canCloseEditorTab(tabId: String): Boolean {
@@ -182,10 +191,19 @@ class MarkdownPreviewerPlugin : IPlugin, UIExtension, EditorTabExtension {
 object PreviewState {
     @Volatile
     var pendingFilePath: String? = null
-    
+
+    @Volatile
+    var pendingUri: android.net.Uri? = null
+
     fun consumePendingFile(): String? {
         val path = pendingFilePath
         pendingFilePath = null
         return path
+    }
+
+    fun consumePendingUri(): android.net.Uri? {
+        val uri = pendingUri
+        pendingUri = null
+        return uri
     }
 }

--- a/markdown-preview/src/main/kotlin/com/codeonthego/markdownpreviewer/fragments/MarkdownPreviewFragment.kt
+++ b/markdown-preview/src/main/kotlin/com/codeonthego/markdownpreviewer/fragments/MarkdownPreviewFragment.kt
@@ -12,31 +12,26 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Button
+import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.ScrollView
 import android.widget.TextView
-import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.codeonthego.markdownpreviewer.MarkdownPreviewerPlugin
 import com.codeonthego.markdownpreviewer.PreviewState
 import com.codeonthego.markdownpreviewer.R
+import com.codeonthego.markdownpreviewer.viewmodel.MarkdownPreviewViewModel
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.itsaky.androidide.plugins.base.PluginFragmentHelper
-import com.itsaky.androidide.plugins.services.IdeProjectService
 import com.itsaky.androidide.plugins.services.IdeFileService
-import io.noties.markwon.Markwon
-import io.noties.markwon.ext.tables.TablePlugin
-import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
-import io.noties.markwon.ext.tasklist.TaskListPlugin
-import io.noties.markwon.html.HtmlPlugin
-import io.noties.markwon.image.ImagesPlugin
-import io.noties.markwon.linkify.LinkifyPlugin
-import kotlinx.coroutines.Dispatchers
+import com.itsaky.androidide.plugins.services.IdeProjectService
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.io.File
 
 class MarkdownPreviewFragment : Fragment() {
@@ -45,28 +40,38 @@ class MarkdownPreviewFragment : Fragment() {
         private const val PLUGIN_ID = MarkdownPreviewerPlugin.PLUGIN_ID
     }
 
+    private val viewModel get() = MarkdownPreviewViewModel
+
     private var projectService: IdeProjectService? = null
     private var fileService: IdeFileService? = null
 
-    // UI Components
     private lateinit var webView: WebView
     private lateinit var progressBar: ProgressBar
     private lateinit var statusContainer: LinearLayout
     private lateinit var statusText: TextView
-    private lateinit var btnSelectFile: Button
-    private lateinit var btnSelectFromStorage: Button
-    private lateinit var btnToggleView: Button
+    private lateinit var btnSelectFile: ImageButton
+    private lateinit var btnSelectFromStorage: ImageButton
+    private lateinit var btnToggleView: ImageButton
+    private lateinit var btnEmptySelectProject: Button
+    private lateinit var btnEmptySelectStorage: Button
     private lateinit var currentFileText: TextView
     private lateinit var placeholderText: TextView
     private lateinit var emptyStateContainer: LinearLayout
     private lateinit var sourceScrollView: ScrollView
     private lateinit var sourceCodeText: TextView
 
-    private var currentFile: File? = null
-    private var currentContent: String? = null
-    private var isShowingSource: Boolean = false
-    private lateinit var markwon: Markwon
-    private var pickFileLauncher: androidx.activity.result.ActivityResultLauncher<Intent>? = null
+    private val pickFileLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode != Activity.RESULT_OK) return@registerForActivityResult
+        val uri = result.data?.data ?: return@registerForActivityResult
+        val ctx = context?.applicationContext
+        if (ctx == null) {
+            PreviewState.pendingUri = uri
+            return@registerForActivityResult
+        }
+        viewModel.loadUri(ctx, uri)
+    }
 
     override fun onGetLayoutInflater(savedInstanceState: Bundle?): LayoutInflater {
         val inflater = super.onGetLayoutInflater(savedInstanceState)
@@ -75,58 +80,50 @@ class MarkdownPreviewFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        // Register activity result launcher early in lifecycle
-        pickFileLauncher = registerForActivityResult(
-            ActivityResultContracts.StartActivityForResult()
-        ) { result ->
-            if (result.resultCode == Activity.RESULT_OK) {
-                val uri = result.data?.data
-                if (uri != null) {
-                    loadFileFromUri(uri)
-                }
-            }
-        }
-
-        // Get services from the plugin's service registry
         runCatching {
             val serviceRegistry = PluginFragmentHelper.getServiceRegistry(PLUGIN_ID)
             projectService = serviceRegistry?.get(IdeProjectService::class.java)
             fileService = serviceRegistry?.get(IdeFileService::class.java)
         }
-
-        // Initialize Markwon with extensions
-        markwon = Markwon.builder(requireContext())
-            .usePlugin(TablePlugin.create(requireContext()))
-            .usePlugin(StrikethroughPlugin.create())
-            .usePlugin(TaskListPlugin.create(requireContext()))
-            .usePlugin(HtmlPlugin.create())
-            .usePlugin(ImagesPlugin.create())
-            .usePlugin(LinkifyPlugin.create())
-            .build()
     }
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.fragment_markdown_preview, container, false)
-    }
+    ): View? = inflater.inflate(R.layout.fragment_markdown_preview, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
         initializeViews(view)
         setupWebView()
         setupClickListeners()
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { render(it) }
+            }
+        }
+
         checkPendingFile()
+        processPendingUri()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (view != null) render(viewModel.uiState.value)
+        processPendingUri()
     }
 
     fun checkPendingFile() {
         PreviewState.consumePendingFile()?.let { path ->
-            loadFile(File(path))
+            viewModel.loadFile(File(path))
         }
+    }
+
+    private fun processPendingUri() {
+        val uri = PreviewState.consumePendingUri() ?: return
+        viewModel.loadUri(requireContext(), uri)
     }
 
     private fun initializeViews(view: View) {
@@ -137,6 +134,8 @@ class MarkdownPreviewFragment : Fragment() {
         btnSelectFile = view.findViewById(R.id.btn_select_file)
         btnSelectFromStorage = view.findViewById(R.id.btn_select_storage)
         btnToggleView = view.findViewById(R.id.btn_toggle_view)
+        btnEmptySelectProject = view.findViewById(R.id.btn_empty_select_project)
+        btnEmptySelectStorage = view.findViewById(R.id.btn_empty_select_storage)
         currentFileText = view.findViewById(R.id.tv_current_file)
         placeholderText = view.findViewById(R.id.tv_placeholder)
         emptyStateContainer = view.findViewById(R.id.empty_state_container)
@@ -154,101 +153,112 @@ class MarkdownPreviewFragment : Fragment() {
             setSupportZoom(true)
             cacheMode = WebSettings.LOAD_NO_CACHE
         }
-
-        webView.webViewClient = object : WebViewClient() {
-            override fun onPageFinished(view: WebView?, url: String?) {
-                super.onPageFinished(view, url)
-                hideProgress()
-            }
-        }
-
-        // Set background color based on theme
-        val isDarkMode = isNightMode()
-        webView.setBackgroundColor(if (isDarkMode) Color.parseColor("#000000") else Color.WHITE)
+        webView.webViewClient = WebViewClient()
+        webView.setBackgroundColor(
+            if (isNightMode()) Color.parseColor("#000000") else Color.WHITE
+        )
     }
 
     private fun setupClickListeners() {
-        btnSelectFile.setOnClickListener {
-            showProjectFilePicker()
-        }
+        val projectClick = View.OnClickListener { showProjectFilePicker() }
+        val storageClick = View.OnClickListener { openFilePicker() }
 
-        btnSelectFromStorage.setOnClickListener {
-            openFilePicker()
-        }
+        btnSelectFile.setOnClickListener(projectClick)
+        btnEmptySelectProject.setOnClickListener(projectClick)
 
-        btnToggleView.setOnClickListener {
-            toggleSourcePreview()
+        btnSelectFromStorage.setOnClickListener(storageClick)
+        btnEmptySelectStorage.setOnClickListener(storageClick)
+
+        btnToggleView.setOnClickListener { viewModel.toggleSource() }
+    }
+
+    private fun render(state: MarkdownPreviewViewModel.UiState) {
+        when (state) {
+            is MarkdownPreviewViewModel.UiState.Empty -> renderEmpty()
+            is MarkdownPreviewViewModel.UiState.Loading -> renderLoading(state.message)
+            is MarkdownPreviewViewModel.UiState.Loaded -> renderLoaded(state)
+            is MarkdownPreviewViewModel.UiState.Error -> renderError(state.message)
         }
     }
 
-    private fun toggleSourcePreview() {
-        isShowingSource = !isShowingSource
-        updateViewMode()
+    private fun renderEmpty() {
+        statusContainer.visibility = View.GONE
+        webView.visibility = View.GONE
+        sourceScrollView.visibility = View.GONE
+        emptyStateContainer.visibility = View.VISIBLE
+        currentFileText.visibility = View.GONE
+        placeholderText.visibility = View.VISIBLE
+        btnToggleView.visibility = View.GONE
     }
 
-    private fun updateViewMode() {
-        if (isShowingSource) {
-            // Show source code
+    private fun renderLoading(message: String) {
+        progressBar.visibility = View.VISIBLE
+        statusContainer.visibility = View.VISIBLE
+        statusContainer.setBackgroundColor(
+            ContextCompat.getColor(requireContext(), R.color.status_background)
+        )
+        statusText.setTextColor(ContextCompat.getColor(requireContext(), R.color.status_text))
+        statusText.text = message
+    }
+
+    private fun renderLoaded(state: MarkdownPreviewViewModel.UiState.Loaded) {
+        progressBar.visibility = View.GONE
+        statusContainer.visibility = View.GONE
+        emptyStateContainer.visibility = View.GONE
+        placeholderText.visibility = View.GONE
+        currentFileText.visibility = View.VISIBLE
+        currentFileText.text = state.fileName
+        btnToggleView.visibility = View.VISIBLE
+
+        if (state.showingSource) {
             webView.visibility = View.GONE
             sourceScrollView.visibility = View.VISIBLE
-            sourceCodeText.text = currentContent ?: ""
-            btnToggleView.text = "Preview"
+            sourceCodeText.text = state.content
+            btnToggleView.setImageResource(R.drawable.ic_visibility)
+            btnToggleView.contentDescription = getString(R.string.view_preview)
+            btnToggleView.tooltipText = getString(R.string.view_preview)
         } else {
-            // Show preview
             sourceScrollView.visibility = View.GONE
             webView.visibility = View.VISIBLE
-            btnToggleView.text = "Source"
+            btnToggleView.setImageResource(R.drawable.ic_source_code)
+            btnToggleView.contentDescription = getString(R.string.view_source)
+            btnToggleView.tooltipText = getString(R.string.view_source)
+            renderHtml(state.content, state.isMarkdown)
         }
+    }
+
+    private fun renderError(message: String) {
+        progressBar.visibility = View.GONE
+        statusContainer.visibility = View.VISIBLE
+        statusText.text = message
+        statusText.setTextColor(ContextCompat.getColor(requireContext(), R.color.status_error_text))
+        statusContainer.setBackgroundColor(
+            ContextCompat.getColor(requireContext(), R.color.status_error_background)
+        )
     }
 
     private fun showProjectFilePicker() {
-        val project = projectService?.getCurrentProject()
-        if (project == null) {
-            showToast("No project available")
-            return
-        }
-
-        // Find all supported files in the project
+        val project = projectService?.getCurrentProject() ?: return
         viewLifecycleOwner.lifecycleScope.launch {
-            showProgress("Scanning project...")
-            
-            val files = withContext(Dispatchers.IO) {
-                findSupportedFiles(project.rootDir)
-            }
-            
-            hideProgress()
-            
-            if (files.isEmpty()) {
-                showToast("No Markdown or HTML files found in project")
-                return@launch
-            }
-
-            // Show file selection dialog
+            val files = findSupportedFiles(project.rootDir)
+            if (files.isEmpty()) return@launch
             showFileSelectionDialog(files, project.rootDir)
         }
     }
 
     private fun findSupportedFiles(rootDir: File): List<File> {
-        val supportedFiles = mutableListOf<File>()
-        
-        rootDir.walkTopDown()
+        return rootDir.walkTopDown()
             .filter { it.isFile && MarkdownPreviewerPlugin.isSupportedFile(it) }
             .filter { !it.absolutePath.contains("/build/") && !it.absolutePath.contains("/.") }
-            .forEach { supportedFiles.add(it) }
-        
-        return supportedFiles.sortedBy { it.name.lowercase() }
+            .sortedBy { it.name.lowercase() }
+            .toList()
     }
 
     private fun showFileSelectionDialog(files: List<File>, rootDir: File) {
-        val fileNames = files.map { file ->
-            file.absolutePath.removePrefix(rootDir.absolutePath + "/")
-        }.toTypedArray()
-
-        android.app.AlertDialog.Builder(requireContext())
+        val fileNames = files.map { it.absolutePath.removePrefix(rootDir.absolutePath + "/") }.toTypedArray()
+        MaterialAlertDialogBuilder(requireContext())
             .setTitle("Select File to Preview")
-            .setItems(fileNames) { _, which ->
-                loadFile(files[which])
-            }
+            .setItems(fileNames) { _, which -> viewModel.loadFile(files[which]) }
             .setNegativeButton("Cancel", null)
             .show()
     }
@@ -261,564 +271,204 @@ class MarkdownPreviewFragment : Fragment() {
                 "text/markdown",
                 "text/x-markdown",
                 "text/html",
+                "application/xhtml+xml",
                 "text/plain"
             ))
         }
-        pickFileLauncher?.launch(intent) ?: showToast("File picker not available")
+        runCatching { pickFileLauncher.launch(intent) }
     }
 
-    private fun loadFileFromUri(uri: Uri) {
-        viewLifecycleOwner.lifecycleScope.launch {
-            showProgress("Loading file...")
-
-            val result = runCatching {
-                withContext(Dispatchers.IO) {
-                    // Get actual filename from ContentResolver
-                    val fileName = getDisplayNameFromUri(uri) ?: "file"
-                    
-                    // Read content from URI
-                    val content = requireContext().contentResolver.openInputStream(uri)?.use { 
-                        it.bufferedReader().readText() 
-                    } ?: throw Exception("Could not read file")
-
-                    // Determine file type
-                    val lowerName = fileName.lowercase()
-                    val isMarkdown = lowerName.endsWith(".md") || 
-                        lowerName.endsWith(".markdown") ||
-                        lowerName.endsWith(".mdown") ||
-                        lowerName.endsWith(".mkd") ||
-                        lowerName.endsWith(".mkdn") ||
-                        // Fallback: check if content looks like markdown
-                        (!lowerName.endsWith(".html") && !lowerName.endsWith(".htm") && 
-                         content.trim().startsWith("#"))
-
-                    Triple(content, isMarkdown, fileName)
-                }
-            }
-
-            result.fold(
-                onSuccess = { (content, isMarkdown, fileName) ->
-                    hideProgress()
-                    currentContent = content
-                    currentFileText.text = fileName
-                    currentFileText.visibility = View.VISIBLE
-                    placeholderText.visibility = View.GONE
-                    emptyStateContainer.visibility = View.GONE
-                    btnToggleView.visibility = View.VISIBLE
-                    isShowingSource = false
-                    webView.visibility = View.VISIBLE
-                    sourceScrollView.visibility = View.GONE
-                    btnToggleView.text = "Source"
-                    renderContent(content, isMarkdown)
-                },
-                onFailure = { e ->
-                    hideProgress()
-                    showError("Failed to load file: ${e.message}")
-                }
-            )
-        }
+    private fun renderHtml(content: String, isMarkdown: Boolean) {
+        val html = if (isMarkdown) buildMarkdownHtml(content) else wrapHtmlContent(content)
+        webView.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null)
     }
 
-    private fun getDisplayNameFromUri(uri: Uri): String? {
-        // Try to get display name from ContentResolver
-        return try {
-            requireContext().contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-                if (cursor.moveToFirst()) {
-                    val nameIndex = cursor.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
-                    if (nameIndex >= 0) {
-                        cursor.getString(nameIndex)
-                    } else null
-                } else null
-            }
-        } catch (e: Exception) {
-            // Fallback to path segment
-            uri.lastPathSegment?.substringAfterLast("/")
-        }
-    }
-
-    private fun loadFile(file: File) {
-        if (!file.exists()) {
-            showError("File not found: ${file.name}")
-            return
-        }
-
-        if (!file.canRead()) {
-            showError("Cannot read file: ${file.name}")
-            return
-        }
-
-        currentFile = file
-
-        viewLifecycleOwner.lifecycleScope.launch {
-            showProgress("Loading ${file.name}...")
-
-            val result = runCatching {
-                withContext(Dispatchers.IO) {
-                    file.readText()
-                }
-            }
-
-            result.fold(
-                onSuccess = { content ->
-                    hideProgress()
-                    currentContent = content
-                    currentFileText.text = file.name
-                    currentFileText.visibility = View.VISIBLE
-                    placeholderText.visibility = View.GONE
-                    emptyStateContainer.visibility = View.GONE
-                    btnToggleView.visibility = View.VISIBLE
-                    isShowingSource = false
-                    webView.visibility = View.VISIBLE
-                    sourceScrollView.visibility = View.GONE
-                    btnToggleView.text = "Source"
-                    
-                    val isMarkdown = MarkdownPreviewerPlugin.isMarkdownFile(file)
-                    renderContent(content, isMarkdown)
-                },
-                onFailure = { e ->
-                    hideProgress()
-                    showError("Failed to load file: ${e.message}")
-                }
-            )
-        }
-    }
-
-    private fun renderContent(content: String, isMarkdown: Boolean) {
-        val html = if (isMarkdown) {
-            convertMarkdownToHtml(content)
-        } else {
-            // Already HTML, just wrap with our styles
-            wrapHtmlContent(content)
-        }
-
-        webView.loadDataWithBaseURL(
-            null,
-            html,
-            "text/html",
-            "UTF-8",
-            null
-        )
-    }
-
-    private fun convertMarkdownToHtml(markdown: String): String {
-        // Use Markwon to convert to HTML-like content
-        // We'll render to a Spanned first, then create styled HTML
-        val styled = markwon.toMarkdown(markdown)
-        
-        // Build HTML with proper styling
+    private fun buildMarkdownHtml(markdown: String): String {
         val isDarkMode = isNightMode()
         val textColor = if (isDarkMode) "#E0E0E0" else "#121212"
         val bgColor = if (isDarkMode) "#000000" else "#FFFFFF"
         val codeBlockBg = if (isDarkMode) "#0D0D0D" else "#F5F5F5"
         val codeBorder = if (isDarkMode) "#1A1A1A" else "#E0E0E0"
-        val linkColor = if (isDarkMode) "#64B5F6" else "#1976D2"
+        val linkColor = if (isDarkMode) "#B1C5FF" else "#485D92"
         val blockquoteBorder = if (isDarkMode) "#616161" else "#BDBDBD"
         val blockquoteBg = if (isDarkMode) "#0A0A0A" else "#FAFAFA"
         val tableBorder = if (isDarkMode) "#1A1A1A" else "#DDDDDD"
         val tableHeaderBg = if (isDarkMode) "#121212" else "#F0F0F0"
-        
+
         return """
             <!DOCTYPE html>
-            <html>
-            <head>
-                <meta charset="UTF-8">
-                <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                <style>
-                    * {
-                        box-sizing: border-box;
-                    }
-                    body {
-                        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-                        font-size: 16px;
-                        line-height: 1.6;
-                        color: $textColor;
-                        background-color: $bgColor;
-                        padding: 16px;
-                        margin: 0;
-                        word-wrap: break-word;
-                    }
-                    h1, h2, h3, h4, h5, h6 {
-                        margin-top: 24px;
-                        margin-bottom: 16px;
-                        font-weight: 600;
-                        line-height: 1.25;
-                    }
-                    h1 { font-size: 2em; border-bottom: 1px solid $codeBorder; padding-bottom: 0.3em; }
-                    h2 { font-size: 1.5em; border-bottom: 1px solid $codeBorder; padding-bottom: 0.3em; }
-                    h3 { font-size: 1.25em; }
-                    h4 { font-size: 1em; }
-                    p {
-                        margin-top: 0;
-                        margin-bottom: 16px;
-                    }
-                    a {
-                        color: $linkColor;
-                        text-decoration: none;
-                    }
-                    a:hover {
-                        text-decoration: underline;
-                    }
-                    code {
-                        font-family: 'SF Mono', Monaco, 'Cascadia Code', Consolas, monospace;
-                        font-size: 0.875em;
-                        background-color: $codeBlockBg;
-                        padding: 0.2em 0.4em;
-                        border-radius: 4px;
-                    }
-                    pre {
-                        background-color: $codeBlockBg;
-                        border: 1px solid $codeBorder;
-                        border-radius: 6px;
-                        padding: 16px;
-                        overflow-x: auto;
-                        font-size: 0.875em;
-                        line-height: 1.45;
-                    }
-                    pre code {
-                        background-color: transparent;
-                        padding: 0;
-                        border-radius: 0;
-                    }
-                    blockquote {
-                        margin: 0 0 16px 0;
-                        padding: 0 16px;
-                        border-left: 4px solid $blockquoteBorder;
-                        background-color: $blockquoteBg;
-                        color: ${if (isDarkMode) "#AAAAAA" else "#666666"};
-                    }
-                    ul, ol {
-                        margin-top: 0;
-                        margin-bottom: 16px;
-                        padding-left: 2em;
-                    }
-                    li {
-                        margin-bottom: 4px;
-                    }
-                    table {
-                        border-collapse: collapse;
-                        width: 100%;
-                        margin-bottom: 16px;
-                    }
-                    th, td {
-                        border: 1px solid $tableBorder;
-                        padding: 8px 12px;
-                        text-align: left;
-                    }
-                    th {
-                        background-color: $tableHeaderBg;
-                        font-weight: 600;
-                    }
-                    img {
-                        max-width: 100%;
-                        height: auto;
-                    }
-                    hr {
-                        border: none;
-                        border-top: 1px solid $codeBorder;
-                        margin: 24px 0;
-                    }
-                    .task-list-item {
-                        list-style-type: none;
-                    }
-                    .task-list-item input[type="checkbox"] {
-                        margin-right: 8px;
-                    }
-                </style>
-            </head>
-            <body>
-                ${convertMarkdownToBasicHtml(markdown)}
-            </body>
-            </html>
+            <html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <style>
+                * { box-sizing: border-box; }
+                body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif; font-size: 16px; line-height: 1.6; color: $textColor; background-color: $bgColor; padding: 16px; margin: 0; word-wrap: break-word; }
+                h1, h2, h3, h4, h5, h6 { margin-top: 24px; margin-bottom: 16px; font-weight: 600; line-height: 1.25; }
+                h1 { font-size: 2em; border-bottom: 1px solid $codeBorder; padding-bottom: 0.3em; }
+                h2 { font-size: 1.5em; border-bottom: 1px solid $codeBorder; padding-bottom: 0.3em; }
+                h3 { font-size: 1.25em; }
+                p { margin-top: 0; margin-bottom: 16px; }
+                a { color: $linkColor; text-decoration: none; }
+                a:hover { text-decoration: underline; }
+                code { font-family: 'SF Mono', Monaco, 'Cascadia Code', Consolas, monospace; font-size: 0.875em; background-color: $codeBlockBg; padding: 0.2em 0.4em; border-radius: 4px; }
+                pre { background-color: $codeBlockBg; border: 1px solid $codeBorder; border-radius: 6px; padding: 16px; overflow-x: auto; font-size: 0.875em; line-height: 1.45; }
+                pre code { background-color: transparent; padding: 0; border-radius: 0; }
+                blockquote { margin: 0 0 16px 0; padding: 0 16px; border-left: 4px solid $blockquoteBorder; background-color: $blockquoteBg; color: ${if (isDarkMode) "#AAAAAA" else "#666666"}; }
+                ul, ol { margin-top: 0; margin-bottom: 16px; padding-left: 2em; }
+                li { margin-bottom: 4px; }
+                table { border-collapse: collapse; width: 100%; margin-bottom: 16px; }
+                th, td { border: 1px solid $tableBorder; padding: 8px 12px; text-align: left; }
+                th { background-color: $tableHeaderBg; font-weight: 600; }
+                img { max-width: 100%; height: auto; }
+                hr { border: none; border-top: 1px solid $codeBorder; margin: 24px 0; }
+                .task-list-item { list-style-type: none; }
+                .task-list-item input[type="checkbox"] { margin-right: 8px; }
+            </style></head><body>${markdownToInnerHtml(markdown)}</body></html>
         """.trimIndent()
     }
 
-    private fun convertMarkdownToBasicHtml(markdown: String): String {
+    private fun markdownToInnerHtml(markdown: String): String {
         var html = markdown
-        
-        // Code blocks (fenced with ```) - must be done first
+
         html = html.replace(Regex("```(\\w*)\\n([\\s\\S]*?)```")) { match ->
             val lang = match.groupValues[1]
             val code = match.groupValues[2].trim()
-                .replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;")
+                .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
             "\n<pre><code class=\"language-$lang\">$code</code></pre>\n"
         }
-        
-        // Inline code
         html = html.replace(Regex("`([^`]+)`")) { match ->
             val code = match.groupValues[1]
-                .replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;")
+                .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
             "<code>$code</code>"
         }
-        
-        // Tables
         html = convertTables(html)
-        
-        // Headers
         html = html.replace(Regex("^######\\s+(.*)$", RegexOption.MULTILINE)) { "<h6>${it.groupValues[1]}</h6>" }
         html = html.replace(Regex("^#####\\s+(.*)$", RegexOption.MULTILINE)) { "<h5>${it.groupValues[1]}</h5>" }
         html = html.replace(Regex("^####\\s+(.*)$", RegexOption.MULTILINE)) { "<h4>${it.groupValues[1]}</h4>" }
         html = html.replace(Regex("^###\\s+(.*)$", RegexOption.MULTILINE)) { "<h3>${it.groupValues[1]}</h3>" }
         html = html.replace(Regex("^##\\s+(.*)$", RegexOption.MULTILINE)) { "<h2>${it.groupValues[1]}</h2>" }
         html = html.replace(Regex("^#\\s+(.*)$", RegexOption.MULTILINE)) { "<h1>${it.groupValues[1]}</h1>" }
-        
-        // Bold and italic
         html = html.replace(Regex("\\*\\*\\*(.+?)\\*\\*\\*")) { "<strong><em>${it.groupValues[1]}</em></strong>" }
         html = html.replace(Regex("___(.+?)___")) { "<strong><em>${it.groupValues[1]}</em></strong>" }
         html = html.replace(Regex("\\*\\*(.+?)\\*\\*")) { "<strong>${it.groupValues[1]}</strong>" }
         html = html.replace(Regex("__(.+?)__")) { "<strong>${it.groupValues[1]}</strong>" }
         html = html.replace(Regex("\\*([^*]+)\\*")) { "<em>${it.groupValues[1]}</em>" }
         html = html.replace(Regex("_([^_]+)_")) { "<em>${it.groupValues[1]}</em>" }
-        
-        // Strikethrough
         html = html.replace(Regex("~~(.+?)~~")) { "<del>${it.groupValues[1]}</del>" }
-        
-        // Links
-        html = html.replace(Regex("\\[([^\\]]+)\\]\\(([^)]+)\\)")) { 
-            "<a href=\"${it.groupValues[2]}\">${it.groupValues[1]}</a>" 
+        html = html.replace(Regex("\\[([^\\]]+)\\]\\(([^)]+)\\)")) {
+            "<a href=\"${it.groupValues[2]}\">${it.groupValues[1]}</a>"
         }
-        
-        // Images
-        html = html.replace(Regex("!\\[([^\\]]*)]\\(([^)]+)\\)")) { 
-            "<img src=\"${it.groupValues[2]}\" alt=\"${it.groupValues[1]}\">" 
+        html = html.replace(Regex("!\\[([^\\]]*)]\\(([^)]+)\\)")) {
+            "<img src=\"${it.groupValues[2]}\" alt=\"${it.groupValues[1]}\">"
         }
-        
-        // Blockquotes
-        html = html.replace(Regex("^>\\s+(.*)$", RegexOption.MULTILINE)) { 
-            "<blockquote>${it.groupValues[1]}</blockquote>" 
+        html = html.replace(Regex("^>\\s+(.*)$", RegexOption.MULTILINE)) {
+            "<blockquote>${it.groupValues[1]}</blockquote>"
         }
-        
-        // Horizontal rules
         html = html.replace(Regex("^(-{3,}|\\*{3,}|_{3,})$", RegexOption.MULTILINE)) { "<hr>" }
-        
-        // Task lists (before regular lists)
-        html = html.replace(Regex("^\\s*-\\s+\\[x\\]\\s+(.*)$", RegexOption.MULTILINE)) { 
-            "<li class=\"task-list-item\"><input type=\"checkbox\" checked disabled> ${it.groupValues[1]}</li>" 
+        html = html.replace(Regex("^\\s*-\\s+\\[x\\]\\s+(.*)$", RegexOption.MULTILINE)) {
+            "<li class=\"task-list-item\"><input type=\"checkbox\" checked disabled> ${it.groupValues[1]}</li>"
         }
-        html = html.replace(Regex("^\\s*-\\s+\\[\\s\\]\\s+(.*)$", RegexOption.MULTILINE)) { 
-            "<li class=\"task-list-item\"><input type=\"checkbox\" disabled> ${it.groupValues[1]}</li>" 
+        html = html.replace(Regex("^\\s*-\\s+\\[\\s\\]\\s+(.*)$", RegexOption.MULTILINE)) {
+            "<li class=\"task-list-item\"><input type=\"checkbox\" disabled> ${it.groupValues[1]}</li>"
         }
-        
-        // Unordered lists
-        html = html.replace(Regex("^\\s*[-*+]\\s+(.*)$", RegexOption.MULTILINE)) { 
-            "<li>${it.groupValues[1]}</li>" 
-        }
-        
-        // Ordered lists
-        html = html.replace(Regex("^\\s*\\d+\\.\\s+(.*)$", RegexOption.MULTILINE)) { 
-            "<li>${it.groupValues[1]}</li>" 
-        }
-        
-        // Wrap consecutive <li> items in <ul>
+        html = html.replace(Regex("^\\s*[-*+]\\s+(.*)$", RegexOption.MULTILINE)) { "<li>${it.groupValues[1]}</li>" }
+        html = html.replace(Regex("^\\s*\\d+\\.\\s+(.*)$", RegexOption.MULTILINE)) { "<li>${it.groupValues[1]}</li>" }
         html = html.replace(Regex("((?:<li[^>]*>.*?</li>\\s*)+)")) { match ->
             val content = match.groupValues[1]
-            if (content.contains("task-list-item")) {
-                "<ul style=\"list-style: none; padding-left: 0;\">$content</ul>"
-            } else {
-                "<ul>$content</ul>"
-            }
+            if (content.contains("task-list-item")) "<ul style=\"list-style: none; padding-left: 0;\">$content</ul>"
+            else "<ul>$content</ul>"
         }
-        
-        // Paragraphs (wrap remaining text blocks)
+
         val lines = html.split("\n")
         val result = StringBuilder()
         var inParagraph = false
-        
         for (line in lines) {
             val trimmed = line.trim()
-            val isBlockElement = trimmed.startsWith("<h") || 
-                trimmed.startsWith("<ul") ||
-                trimmed.startsWith("<ol") ||
-                trimmed.startsWith("<table") ||
-                trimmed.startsWith("<blockquote") ||
-                trimmed.startsWith("<pre") ||
-                trimmed.startsWith("<hr") ||
-                trimmed.startsWith("</")
-            
+            val isBlockElement = trimmed.startsWith("<h") || trimmed.startsWith("<ul") ||
+                trimmed.startsWith("<ol") || trimmed.startsWith("<table") ||
+                trimmed.startsWith("<blockquote") || trimmed.startsWith("<pre") ||
+                trimmed.startsWith("<hr") || trimmed.startsWith("</")
             when {
                 trimmed.isEmpty() -> {
-                    if (inParagraph) {
-                        result.append("</p>\n")
-                        inParagraph = false
-                    }
+                    if (inParagraph) { result.append("</p>\n"); inParagraph = false }
                     result.append("\n")
                 }
                 isBlockElement -> {
-                    if (inParagraph) {
-                        result.append("</p>\n")
-                        inParagraph = false
-                    }
+                    if (inParagraph) { result.append("</p>\n"); inParagraph = false }
                     result.append(trimmed).append("\n")
                 }
                 else -> {
-                    if (!inParagraph) {
-                        result.append("<p>")
-                        inParagraph = true
-                    } else {
-                        result.append("<br>")
-                    }
+                    if (!inParagraph) { result.append("<p>"); inParagraph = true }
+                    else result.append("<br>")
                     result.append(trimmed)
                 }
             }
         }
-        if (inParagraph) {
-            result.append("</p>")
-        }
-        
+        if (inParagraph) result.append("</p>")
         return result.toString()
     }
-    
+
     private fun convertTables(markdown: String): String {
         val lines = markdown.split("\n")
         val result = StringBuilder()
         var inTable = false
         var headerProcessed = false
-        
         for (i in lines.indices) {
             val line = lines[i].trim()
-            
-            // Check if this is a table row (contains |)
             if (line.startsWith("|") && line.endsWith("|")) {
-                // Check if next line is separator (|---|---|)
-                val isHeader = i + 1 < lines.size && 
+                val isHeader = i + 1 < lines.size &&
                     lines[i + 1].trim().matches(Regex("\\|[-:\\s|]+\\|"))
-                
-                // Check if this line IS a separator
                 val isSeparator = line.matches(Regex("\\|[-:\\s|]+\\|"))
-                
-                if (isSeparator) {
-                    // Skip separator line
-                    continue
-                }
-                
+                if (isSeparator) continue
                 if (!inTable) {
-                    result.append("<table>\n")
-                    inTable = true
-                    headerProcessed = false
+                    result.append("<table>\n"); inTable = true; headerProcessed = false
                 }
-                
-                val cells = line.split("|")
-                    .filter { it.isNotBlank() }
-                    .map { it.trim() }
-                
+                val cells = line.split("|").filter { it.isNotBlank() }.map { it.trim() }
                 if (isHeader && !headerProcessed) {
                     result.append("<thead><tr>")
-                    cells.forEach { cell -> result.append("<th>$cell</th>") }
+                    cells.forEach { result.append("<th>$it</th>") }
                     result.append("</tr></thead>\n<tbody>\n")
                     headerProcessed = true
                 } else {
                     result.append("<tr>")
-                    cells.forEach { cell -> result.append("<td>$cell</td>") }
+                    cells.forEach { result.append("<td>$it</td>") }
                     result.append("</tr>\n")
                 }
             } else {
                 if (inTable) {
-                    result.append("</tbody></table>\n")
-                    inTable = false
-                    headerProcessed = false
+                    result.append("</tbody></table>\n"); inTable = false; headerProcessed = false
                 }
                 result.append(line).append("\n")
             }
         }
-        
-        if (inTable) {
-            result.append("</tbody></table>\n")
-        }
-        
+        if (inTable) result.append("</tbody></table>\n")
         return result.toString()
     }
 
     private fun wrapHtmlContent(html: String): String {
-        // If already has <html> tag, return as-is with dark mode support injected
-        if (html.lowercase().contains("<html")) {
-            return injectDarkModeStyles(html)
-        }
-
+        if (html.lowercase().contains("<html")) return injectDarkModeStyles(html)
         val isDarkMode = isNightMode()
         val textColor = if (isDarkMode) "#E0E0E0" else "#121212"
         val bgColor = if (isDarkMode) "#000000" else "#FFFFFF"
-
         return """
-            <!DOCTYPE html>
-            <html>
-            <head>
-                <meta charset="UTF-8">
-                <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                <style>
-                    body {
-                        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-                        font-size: 16px;
-                        line-height: 1.6;
-                        color: $textColor;
-                        background-color: $bgColor;
-                        padding: 16px;
-                        margin: 0;
-                    }
-                    img { max-width: 100%; height: auto; }
-                </style>
-            </head>
-            <body>
-                $html
-            </body>
-            </html>
+            <!DOCTYPE html><html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <style>body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.6; color: $textColor; background-color: $bgColor; padding: 16px; margin: 0; } img { max-width: 100%; height: auto; }</style>
+            </head><body>$html</body></html>
         """.trimIndent()
     }
 
     private fun injectDarkModeStyles(html: String): String {
         if (!isNightMode()) return html
-
-        val darkModeStyle = """
-            <style>
-                body { 
-                    background-color: #000000 !important; 
-                    color: #E0E0E0 !important; 
-                }
-            </style>
-        """.trimIndent()
-
-        return if (html.lowercase().contains("<head>")) {
-            html.replace(Regex("<head>", RegexOption.IGNORE_CASE)) { 
-                "<head>$darkModeStyle" 
-            }
-        } else if (html.lowercase().contains("<html>")) {
-            html.replace(Regex("<html>", RegexOption.IGNORE_CASE)) { 
-                "<html><head>$darkModeStyle</head>" 
-            }
-        } else {
-            "$darkModeStyle$html"
+        val darkModeStyle = "<style>body { background-color: #000000 !important; color: #E0E0E0 !important; }</style>"
+        return when {
+            html.lowercase().contains("<head>") ->
+                html.replace(Regex("<head>", RegexOption.IGNORE_CASE)) { "<head>$darkModeStyle" }
+            html.lowercase().contains("<html>") ->
+                html.replace(Regex("<html>", RegexOption.IGNORE_CASE)) { "<html><head>$darkModeStyle</head>" }
+            else -> "$darkModeStyle$html"
         }
     }
 
-    private fun isNightMode(): Boolean {
-        return (resources.configuration.uiMode and 
-                android.content.res.Configuration.UI_MODE_NIGHT_MASK) == 
-                android.content.res.Configuration.UI_MODE_NIGHT_YES
-    }
-
-    private fun showProgress(message: String) {
-        progressBar.visibility = View.VISIBLE
-        statusContainer.visibility = View.VISIBLE
-        statusText.text = message
-    }
-
-    private fun hideProgress() {
-        progressBar.visibility = View.GONE
-        statusContainer.visibility = View.GONE
-    }
-
-    private fun showError(message: String) {
-        statusContainer.visibility = View.VISIBLE
-        statusText.text = message
-        statusText.setTextColor(ContextCompat.getColor(requireContext(), R.color.status_error_text))
-        statusContainer.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.status_error_background))
-    }
-
-    private fun showToast(message: String) {
-        activity?.runOnUiThread {
-            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
-        }
-    }
+    private fun isNightMode(): Boolean =
+        (resources.configuration.uiMode and
+            android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
+            android.content.res.Configuration.UI_MODE_NIGHT_YES
 }

--- a/markdown-preview/src/main/kotlin/com/codeonthego/markdownpreviewer/viewmodel/MarkdownPreviewViewModel.kt
+++ b/markdown-preview/src/main/kotlin/com/codeonthego/markdownpreviewer/viewmodel/MarkdownPreviewViewModel.kt
@@ -1,0 +1,143 @@
+package com.codeonthego.markdownpreviewer.viewmodel
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Process-wide singleton store for the markdown preview state. Plugin fragments
+ * don't share a ViewModelStore reliably across classloader and host-activity
+ * boundaries, so the state lives here and every fragment observes the same
+ * StateFlow. Survives fragment recreation, theme changes, and activity restarts;
+ * only process death wipes it.
+ */
+object MarkdownPreviewViewModel {
+
+    private const val TAG = "MarkdownPreviewer"
+    private val MARKDOWN_EXTENSIONS = setOf("md", "markdown", "mdown", "mkd", "mkdn")
+    private val HTML_EXTENSIONS = setOf("html", "htm", "xhtml")
+
+    sealed interface UiState {
+        data object Empty : UiState
+        data class Loading(val message: String) : UiState
+        data class Loaded(
+            val fileName: String,
+            val content: String,
+            val isMarkdown: Boolean,
+            val showingSource: Boolean
+        ) : UiState
+        data class Error(val message: String) : UiState
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val _uiState = MutableStateFlow<UiState>(UiState.Empty)
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    private var loadJob: Job? = null
+
+    fun loadFile(file: File) {
+        if (!file.exists()) {
+            _uiState.value = UiState.Error("File not found: ${file.name}")
+            return
+        }
+        if (!file.canRead()) {
+            _uiState.value = UiState.Error("Cannot read file: ${file.name}")
+            return
+        }
+        if (!isSupported(file.name)) {
+            _uiState.value = UiState.Error("Unsupported file type. Only Markdown and HTML files are allowed.")
+            return
+        }
+        launchLoad(file.name) {
+            val content = file.readText()
+            val isMarkdown = MARKDOWN_EXTENSIONS.contains(file.extension.lowercase())
+            content to isMarkdown
+        }
+    }
+
+    fun loadUri(context: Context, uri: Uri) {
+        val appContext = context.applicationContext
+        val displayName = resolveDisplayName(appContext, uri) ?: "file"
+        if (!isSupported(displayName)) {
+            _uiState.value = UiState.Error("Unsupported file type. Only Markdown and HTML files are allowed.")
+            return
+        }
+        launchLoad(displayName) {
+            val stream = appContext.contentResolver.openInputStream(uri)
+                ?: throw IllegalStateException("Could not open URI: $uri")
+            val content = stream.use { it.bufferedReader().readText() }
+            val isMarkdown = inferIsMarkdown(displayName, content)
+            content to isMarkdown
+        }
+    }
+
+    private fun isSupported(fileName: String): Boolean {
+        val ext = fileName.substringAfterLast('.', "").lowercase()
+        return ext in MARKDOWN_EXTENSIONS || ext in HTML_EXTENSIONS
+    }
+
+    fun toggleSource() {
+        val current = _uiState.value
+        if (current is UiState.Loaded) {
+            _uiState.value = current.copy(showingSource = !current.showingSource)
+        }
+    }
+
+    fun reset() {
+        loadJob?.cancel()
+        _uiState.value = UiState.Empty
+    }
+
+    private fun launchLoad(fileName: String, block: suspend () -> Pair<String, Boolean>) {
+        loadJob?.cancel()
+        _uiState.value = UiState.Loading("Loading $fileName…")
+        loadJob = scope.launch {
+            try {
+                val (content, isMarkdown) = withContext(Dispatchers.IO) { block() }
+                _uiState.value = UiState.Loaded(
+                    fileName = fileName,
+                    content = content,
+                    isMarkdown = isMarkdown,
+                    showingSource = false
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to load $fileName", e)
+                _uiState.value = UiState.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    private fun resolveDisplayName(context: Context, uri: Uri): String? {
+        return try {
+            context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (nameIndex >= 0) cursor.getString(nameIndex) else null
+                } else null
+            } ?: uri.lastPathSegment?.substringAfterLast("/")
+        } catch (e: Exception) {
+            uri.lastPathSegment?.substringAfterLast("/")
+        }
+    }
+
+    private fun inferIsMarkdown(fileName: String, content: String): Boolean {
+        val ext = fileName.substringAfterLast('.', "").lowercase()
+        if (ext in MARKDOWN_EXTENSIONS) return true
+        if (ext in HTML_EXTENSIONS) return false
+        return content.trim().startsWith("#")
+    }
+}

--- a/markdown-preview/src/main/res/drawable/ic_folder.xml
+++ b/markdown-preview/src/main/res/drawable/ic_folder.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+
+    <path
+        android:fillColor="#000000"
+        android:pathData="M10,4L4,4C2.9,4 2.01,4.9 2.01,6L2,18C2,19.1 2.9,20 4,20L20,20C21.1,20 22,19.1 22,18L22,8C22,6.9 21.1,6 20,6L12,6L10,4Z"/>
+</vector>

--- a/markdown-preview/src/main/res/drawable/ic_preview.xml
+++ b/markdown-preview/src/main/res/drawable/ic_preview.xml
@@ -3,10 +3,10 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
-    
-    <!-- Eye icon - visibility/preview -->
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+
     <path
-        android:fillColor="#FF000000"
-        android:pathData="M12,4.5C7,4.5 2.73,7.61 1,12c1.73,4.39 6,7.5 11,7.5s9.27,-3.11 11,-7.5c-1.73,-4.39 -6,-7.5 -11,-7.5zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5zM12,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3 3,-1.34 3,-3 -1.34,-3 -3,-3z"/>
+        android:fillColor="#000000"
+        android:pathData="M14,2L6,2C4.9,2 4.01,2.9 4.01,4L4,20C4,21.1 4.89,22 5.99,22L18,22C19.1,22 20,21.1 20,20L20,8L14,2ZM13,3.5L18.5,9L14,9C13.45,9 13,8.55 13,8L13,3.5ZM7,12L17,12L17,14L7,14L7,12ZM7,16L17,16L17,18L7,18L7,16Z"/>
 </vector>

--- a/markdown-preview/src/main/res/drawable/ic_source_code.xml
+++ b/markdown-preview/src/main/res/drawable/ic_source_code.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+
+    <path
+        android:fillColor="#000000"
+        android:pathData="M9.4,16.6L4.8,12L9.4,7.4L8,6L2,12L8,18L9.4,16.6ZM14.6,16.6L19.2,12L14.6,7.4L16,6L22,12L16,18L14.6,16.6Z"/>
+</vector>

--- a/markdown-preview/src/main/res/drawable/ic_storage.xml
+++ b/markdown-preview/src/main/res/drawable/ic_storage.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+
+    <path
+        android:fillColor="#000000"
+        android:pathData="M2,20L22,20L22,4L2,4L2,20ZM4,18L4,6L20,6L20,18L4,18ZM6,8L8,8L8,16L6,16L6,8ZM10,8L12,8L12,16L10,16L10,8Z"/>
+</vector>

--- a/markdown-preview/src/main/res/drawable/ic_visibility.xml
+++ b/markdown-preview/src/main/res/drawable/ic_visibility.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+
+    <path
+        android:fillColor="#000000"
+        android:pathData="M12,4.5C7,4.5 2.73,7.61 1,12c1.73,4.39 6,7.5 11,7.5s9.27,-3.11 11,-7.5c-1.73,-4.39 -6,-7.5 -11,-7.5zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5zM12,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3 3,-1.34 3,-3 -1.34,-3 -3,-3z"/>
+</vector>

--- a/markdown-preview/src/main/res/layout/fragment_markdown_preview.xml
+++ b/markdown-preview/src/main/res/layout/fragment_markdown_preview.xml
@@ -4,76 +4,73 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:background="?android:attr/colorBackground">
+    android:background="?attr/colorSurface">
 
-    <!-- Compact Header -->
+    <!-- Toolbar -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:paddingHorizontal="8dp"
-        android:paddingVertical="6dp"
-        android:background="?android:attr/colorBackgroundFloating"
-        android:elevation="2dp"
+        android:paddingHorizontal="12dp"
+        android:paddingVertical="8dp"
         android:gravity="center_vertical">
 
-        <!-- Current file name (shown when file loaded) -->
         <TextView
             android:id="@+id/tv_current_file"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:textSize="14sp"
-            android:textColor="?android:attr/textColorPrimary"
+            android:textColor="?attr/colorOnSurface"
+            android:textStyle="bold"
             android:ellipsize="middle"
             android:singleLine="true"
             android:visibility="gone" />
 
-        <!-- Placeholder when no file -->
         <TextView
             android:id="@+id/tv_placeholder"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="Select a file"
+            android:text="@string/plugin_title"
             android:textSize="14sp"
-            android:textColor="?android:attr/textColorSecondary" />
+            android:textStyle="bold"
+            android:textColor="?attr/colorOnSurface" />
 
-        <Button
+        <ImageButton
             android:id="@+id/btn_select_file"
-            android:layout_width="wrap_content"
-            android:layout_height="36dp"
-            android:minWidth="0dp"
-            android:text="Project"
-            android:textColor="#00BE00"
-            android:textSize="12sp"
-            android:paddingHorizontal="12dp"
-            style="@style/Widget.Material3.Button.TextButton" />
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:src="@drawable/ic_folder"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/select_from_project"
+            android:tooltipText="@string/select_from_project" />
 
-        <Button
+        <ImageButton
             android:id="@+id/btn_select_storage"
-            android:layout_width="wrap_content"
-            android:layout_height="36dp"
-            android:minWidth="0dp"
-            android:text="Storage"
-            android:textColor="#00BE00"
-            android:textSize="12sp"
-            android:paddingHorizontal="12dp"
-            style="@style/Widget.Material3.Button.TextButton" />
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:src="@drawable/ic_storage"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/select_from_storage"
+            android:tooltipText="@string/select_from_storage" />
 
-        <Button
+        <ImageButton
             android:id="@+id/btn_toggle_view"
-            android:layout_width="wrap_content"
-            android:layout_height="36dp"
-            android:minWidth="0dp"
-            android:text="Source"
-            android:textColor="#00BE00"
-            android:textSize="12sp"
-            android:paddingHorizontal="12dp"
-            android:visibility="gone"
-            style="@style/Widget.Material3.Button.TonalButton" />
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:src="@drawable/ic_source_code"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/view_source"
+            android:tooltipText="@string/view_source"
+            android:visibility="gone" />
 
     </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="?attr/colorOutlineVariant" />
 
     <!-- Status container -->
     <LinearLayout
@@ -88,8 +85,8 @@
 
         <ProgressBar
             android:id="@+id/progress_bar"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
             android:layout_marginEnd="12dp"
             style="@style/Widget.AppCompat.ProgressBar" />
 
@@ -98,7 +95,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textSize="14sp"
+            android:textSize="13sp"
             android:textColor="@color/status_text" />
 
     </LinearLayout>
@@ -111,33 +108,60 @@
         android:layout_weight="1"
         android:orientation="vertical"
         android:gravity="center"
-        android:padding="32dp">
+        android:paddingHorizontal="32dp">
+
+        <ImageView
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:src="@drawable/ic_preview"
+            android:contentDescription="@null"
+            app:tint="?attr/colorPrimary" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
             android:text="@string/empty_state_title"
             android:textSize="18sp"
             android:textStyle="bold"
-            android:textColor="?android:attr/textColorPrimary" />
+            android:textColor="?attr/colorOnSurface" />
 
         <TextView
             android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="@string/empty_state_subtitle"
+            android:textSize="13sp"
+            android:textColor="?attr/colorOnSurface"
+            android:alpha="0.7"
+            android:gravity="center"
+            android:lineSpacingMultiplier="1.4" />
+
+        <Button
+            android:id="@+id/btn_empty_select_project"
+            android:layout_width="220dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/select_from_project" />
+
+        <Button
+            android:id="@+id/btn_empty_select_storage"
+            android:layout_width="220dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:text="@string/empty_state_subtitle"
-            android:textSize="14sp"
-            android:textColor="?android:attr/textColorSecondary"
-            android:gravity="center" />
+            android:text="@string/select_from_storage" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="24dp"
             android:text="@string/supported_formats"
-            android:textSize="12sp"
-            android:textColor="?android:attr/textColorTertiary"
-            android:gravity="center" />
+            android:textSize="11sp"
+            android:textColor="?attr/colorOnSurface"
+            android:alpha="0.55"
+            android:gravity="center"
+            android:letterSpacing="0.04"
+            android:textAllCaps="true" />
 
     </LinearLayout>
 
@@ -156,7 +180,7 @@
         android:layout_height="0dp"
         android:layout_weight="1"
         android:visibility="gone"
-        android:background="?android:attr/colorBackground">
+        android:background="?attr/colorSurface">
 
         <TextView
             android:id="@+id/tv_source_code"
@@ -165,7 +189,7 @@
             android:padding="16dp"
             android:fontFamily="monospace"
             android:textSize="13sp"
-            android:textColor="?android:attr/textColorPrimary"
+            android:textColor="?attr/colorOnSurface"
             android:lineSpacingMultiplier="1.2" />
 
     </ScrollView>

--- a/markdown-preview/src/main/res/values-night/colors.xml
+++ b/markdown-preview/src/main/res/values-night/colors.xml
@@ -1,26 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Primary Colors -->
-    <color name="primary">#64B5F6</color>
-    <color name="primary_dark">#42A5F5</color>
-    <color name="accent">#90CAF9</color>
+    <color name="plugin_primary">#B1C5FF</color>
+    <color name="plugin_on_primary">#172E60</color>
+    <color name="plugin_primary_container">#304578</color>
+    <color name="plugin_on_primary_container">#DAE2FF</color>
 
-    <!-- Status Colors -->
-    <color name="status_background">#0D1117</color>
-    <color name="status_text">#90CAF9</color>
+    <color name="status_text">#E4E2E6</color>
+    <color name="status_background">#44464F</color>
 
-    <color name="status_success_background">#0D1F12</color>
     <color name="status_success_text">#81C784</color>
+    <color name="status_success_background">#1B3A1B</color>
 
-    <color name="status_error_background">#1F0D0D</color>
-    <color name="status_error_text">#EF9A9A</color>
-
-    <color name="status_warning_background">#1F170D</color>
-    <color name="status_warning_text">#FFCC80</color>
-
-    <!-- Preview Colors - True black to match IDE -->
-    <color name="preview_background">#000000</color>
-    <color name="preview_text">#E0E0E0</color>
-    <color name="preview_code_background">#121212</color>
-    <color name="preview_link">#64B5F6</color>
+    <color name="status_error_text">#F2B8B5</color>
+    <color name="status_error_background">#8C1D18</color>
 </resources>

--- a/markdown-preview/src/main/res/values/colors.xml
+++ b/markdown-preview/src/main/res/values/colors.xml
@@ -1,26 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Primary Colors -->
-    <color name="primary">#1976D2</color>
-    <color name="primary_dark">#1565C0</color>
-    <color name="accent">#64B5F6</color>
+    <color name="plugin_primary">#485D92</color>
+    <color name="plugin_on_primary">#FFFFFF</color>
+    <color name="plugin_primary_container">#DAE2FF</color>
+    <color name="plugin_on_primary_container">#001847</color>
 
-    <!-- Status Colors -->
-    <color name="status_background">#E3F2FD</color>
-    <color name="status_text">#1565C0</color>
+    <color name="status_text">#1B1B1F</color>
+    <color name="status_background">#E1E2EC</color>
 
-    <color name="status_success_background">#E8F5E9</color>
     <color name="status_success_text">#2E7D32</color>
+    <color name="status_success_background">#E8F5E9</color>
 
-    <color name="status_error_background">#FFEBEE</color>
-    <color name="status_error_text">#C62828</color>
-
-    <color name="status_warning_background">#FFF3E0</color>
-    <color name="status_warning_text">#EF6C00</color>
-
-    <!-- Preview Colors -->
-    <color name="preview_background">#FFFFFF</color>
-    <color name="preview_text">#333333</color>
-    <color name="preview_code_background">#F5F5F5</color>
-    <color name="preview_link">#1976D2</color>
+    <color name="status_error_text">#B3261E</color>
+    <color name="status_error_background">#F9DEDC</color>
 </resources>

--- a/markdown-preview/src/main/res/values/styles.xml
+++ b/markdown-preview/src/main/res/values/styles.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.MarkdownPreviewer" parent="Theme.Material3.DayNight">
-        <item name="colorPrimary">@color/primary</item>
-        <item name="colorPrimaryDark">@color/primary_dark</item>
-        <item name="colorAccent">@color/accent</item>
+    <style name="PluginTheme" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/plugin_primary</item>
+        <item name="colorOnPrimary">@color/plugin_on_primary</item>
+        <item name="colorPrimaryContainer">@color/plugin_primary_container</item>
+        <item name="colorOnPrimaryContainer">@color/plugin_on_primary_container</item>
+        <item name="android:colorPrimary">@color/plugin_primary</item>
+        <item name="android:colorAccent">@color/plugin_primary</item>
     </style>
 </resources>

--- a/random-xkcd/src/main/res/layout/fragment_xkcd_panel.xml
+++ b/random-xkcd/src/main/res/layout/fragment_xkcd_panel.xml
@@ -33,40 +33,49 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="0.8"
-                android:text="@string/btn_first"
-                style="?attr/buttonBarButtonStyle" />
+                android:layout_marginEnd="4dp"
+                android:minWidth="0dp"
+                android:paddingHorizontal="0dp"
+                android:text="@string/btn_first" />
 
             <Button
                 android:id="@+id/xkcd_btn_prev"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1.0"
-                android:text="@string/btn_prev"
-                style="?attr/buttonBarButtonStyle" />
+                android:layout_marginEnd="4dp"
+                android:minWidth="0dp"
+                android:paddingHorizontal="0dp"
+                android:text="@string/btn_prev" />
 
             <Button
                 android:id="@+id/xkcd_btn_random"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1.4"
-                android:text="@string/btn_random"
-                style="?attr/buttonBarButtonStyle" />
+                android:layout_marginEnd="4dp"
+                android:minWidth="0dp"
+                android:paddingHorizontal="0dp"
+                android:text="@string/btn_random" />
 
             <Button
                 android:id="@+id/xkcd_btn_next"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1.0"
-                android:text="@string/btn_next"
-                style="?attr/buttonBarButtonStyle" />
+                android:layout_marginEnd="4dp"
+                android:minWidth="0dp"
+                android:paddingHorizontal="0dp"
+                android:text="@string/btn_next" />
 
             <Button
                 android:id="@+id/xkcd_btn_last"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="0.8"
-                android:text="@string/btn_last"
-                style="?attr/buttonBarButtonStyle" />
+                android:minWidth="0dp"
+                android:paddingHorizontal="0dp"
+                android:text="@string/btn_last" />
         </LinearLayout>
 
         <!-- Title row: comic number + title, in the xkcd.com style.

--- a/snippets/src/main/kotlin/com/codeonthego/snippets/ui/SnippetManagerFragment.kt
+++ b/snippets/src/main/kotlin/com/codeonthego/snippets/ui/SnippetManagerFragment.kt
@@ -3,8 +3,11 @@ package com.codeonthego.snippets.ui
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
+import androidx.appcompat.app.AlertDialog
+import androidx.core.content.ContextCompat
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.ArrayAdapter
@@ -17,7 +20,6 @@ import com.codeonthego.snippets.SnippetEntry
 import com.codeonthego.snippets.SnippetsConfig
 import com.codeonthego.snippets.SnippetsConfigParser
 import com.codeonthego.snippets.SnippetsPlugin
-import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
@@ -58,7 +60,7 @@ class SnippetManagerFragment : Fragment() {
         emptyView = view.findViewById(R.id.emptyView)
         snippetCount = view.findViewById(R.id.snippetCount)
 
-        view.findViewById<MaterialButton>(R.id.btnAdd).setOnClickListener {
+        view.findViewById<Button>(R.id.btnAdd).setOnClickListener {
             showEditor(null, -1)
         }
     }
@@ -141,7 +143,7 @@ class SnippetManagerFragment : Fragment() {
             scopeSpinner.setSelection(1)
         }
 
-        MaterialAlertDialogBuilder(ctx)
+        val editDialog = MaterialAlertDialogBuilder(ctx)
             .setTitle(if (existing != null) "Edit Snippet" else "New Snippet")
             .setView(dialogView)
             .setPositiveButton("Save") { _, _ ->
@@ -175,13 +177,14 @@ class SnippetManagerFragment : Fragment() {
             }
             .setNegativeButton("Cancel", null)
             .show()
+        applyDialogButtonColors(editDialog)
     }
 
     private fun confirmDelete(index: Int) {
         val ctx = context ?: return
         val entry = snippets.getOrNull(index) ?: return
 
-        MaterialAlertDialogBuilder(ctx)
+        val deleteDialog = MaterialAlertDialogBuilder(ctx)
             .setTitle("Delete Snippet")
             .setMessage("Delete \"${entry.prefix}\"?")
             .setPositiveButton("Delete") { _, _ ->
@@ -191,6 +194,15 @@ class SnippetManagerFragment : Fragment() {
             }
             .setNegativeButton("Cancel", null)
             .show()
+        applyDialogButtonColors(deleteDialog)
+    }
+
+    private fun applyDialogButtonColors(dialog: AlertDialog) {
+        val ctx = context ?: return
+        val color = ContextCompat.getColor(ctx, R.color.plugin_primary)
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE)?.setTextColor(color)
+        dialog.getButton(AlertDialog.BUTTON_NEGATIVE)?.setTextColor(color)
+        dialog.getButton(AlertDialog.BUTTON_NEUTRAL)?.setTextColor(color)
     }
 
     private fun save() {

--- a/snippets/src/main/res/layout/fragment_snippet_manager.xml
+++ b/snippets/src/main/res/layout/fragment_snippet_manager.xml
@@ -32,16 +32,13 @@
             android:textColor="?android:attr/textColorSecondary"
             android:paddingEnd="4dp" />
 
-        <com.google.android.material.button.MaterialButton
+        <Button
             android:id="@+id/btnAdd"
-            style="@style/Widget.Material3.Button.OutlinedButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:minWidth="0dp"
             android:text="+ Add"
-            android:textSize="13sp"
-            android:textColor="?android:attr/textColorPrimary"
-            app:strokeColor="?attr/colorOutline"
-            app:rippleColor="?attr/colorOutlineVariant" />
+            android:textSize="13sp" />
 
     </LinearLayout>
 

--- a/snippets/src/main/res/values-night/colors.xml
+++ b/snippets/src/main/res/values-night/colors.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="plugin_primary">#5EEAD4</color>
+    <color name="plugin_on_primary">#002117</color>
+    <color name="plugin_primary_container">#115E59</color>
+    <color name="plugin_on_primary_container">#A7F3D0</color>
+
+    <color name="plugin_on_surface">#E5E5E5</color>
+</resources>

--- a/snippets/src/main/res/values/colors.xml
+++ b/snippets/src/main/res/values/colors.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="plugin_primary">#0F766E</color>
+    <color name="plugin_on_primary">#FFFFFF</color>
+    <color name="plugin_primary_container">#A7F3D0</color>
+    <color name="plugin_on_primary_container">#002117</color>
+
+    <color name="plugin_on_surface">#171717</color>
+</resources>

--- a/snippets/src/main/res/values/styles.xml
+++ b/snippets/src/main/res/values/styles.xml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="PluginTheme" parent="Theme.Material3.DayNight.NoActionBar">
-        <item name="colorPrimary">#0f766e</item>
-        <item name="colorOnPrimary">#FFFFFF</item>
-        <item name="colorPrimaryContainer">#A7F3D0</item>
-        <item name="colorOnPrimaryContainer">#002117</item>
-        <item name="colorSecondary">#4B635B</item>
-        <item name="colorOnSecondary">#FFFFFF</item>
-        <item name="colorSurface">#FAFAFA</item>
-        <item name="colorOnSurface">#171717</item>
-        <item name="colorOnSurfaceVariant">#404040</item>
-        <item name="colorOutline">#737373</item>
-        <item name="colorOutlineVariant">#D4D4D4</item>
+        <item name="colorPrimary">@color/plugin_primary</item>
+        <item name="colorOnPrimary">@color/plugin_on_primary</item>
+        <item name="colorPrimaryContainer">@color/plugin_primary_container</item>
+        <item name="colorOnPrimaryContainer">@color/plugin_on_primary_container</item>
     </style>
 </resources>


### PR DESCRIPTION

  - markdown-preview: redesign empty state + toolbar, adopt apk-analyzer theme tokens, move state to a process-wide store (survives theme changes), restrict picker to md/html, new doc icon, reset on tab close
  - random-xkcd: convert nav buttons to plain theme-driven Buttons for legible text in light/dark
  - snippets: extract colors to light/dark resources, plain Button for +Add, theme-colored dialog buttons
  - ci: add build-plugins.yml that builds .cgp files as downloadable artifacts (no lib commit, release, or deploy)