### PR TITLE
icons-repository now uses the same versions of everything we do elsewhere

### DIFF
--- a/icons-repository/build.gradle.kts
+++ b/icons-repository/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -10,12 +12,11 @@ pluginBuilder {
 
 android {
     namespace = "dev.omar.plugin.iconsrepo"
-    compileSdk = 35
-    buildToolsVersion = "37.0.0"
+    compileSdk = 34
     defaultConfig {
         applicationId = "dev.omar.plugin.iconsrepo"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0.0"
     }
@@ -32,16 +33,28 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-    
     buildFeatures {
         viewBinding = true
     }
-    
 
+    packaging {
+        resources {
+            excludes += setOf(
+                "META-INF/versions/9/OSGI-INF/MANIFEST.MF",
+                "META-INF/DEPENDENCIES",
+                "META-INF/LICENSE",
+                "META-INF/LICENSE.txt",
+                "META-INF/NOTICE",
+                "META-INF/NOTICE.txt"
+            )
+        }
+    }
+}
 
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
 }
 
 dependencies {

--- a/icons-repository/settings.gradle.kts
+++ b/icons-repository/settings.gradle.kts
@@ -1,8 +1,5 @@
 pluginManagement {
     repositories {
-        maven { url = uri("https://maven.aliyun.com/repository/google") }
-        maven { url = uri("https://maven.aliyun.com/repository/public") }
-        maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
         google()
         mavenCentral()
         gradlePluginPortal()
@@ -11,26 +8,20 @@ pluginManagement {
 
 buildscript {
     repositories {
-        maven { url = uri("https://maven.aliyun.com/repository/google") }
-        maven { url = uri("https://maven.aliyun.com/repository/public") }
-        maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
         google()
         mavenCentral()
     }
     dependencies {
         classpath(files("../libs/plugin-api.jar"))
         classpath(files("../libs/gradle-plugin.jar"))
-        classpath("com.android.tools.build:gradle:8.12.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.0")
+        classpath("com.android.tools.build:gradle:8.11.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.0")
     }
 }
 
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        maven { url = uri("https://maven.aliyun.com/repository/google") }
-        maven { url = uri("https://maven.aliyun.com/repository/public") }
-        maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
         maven { url = uri("https://jitpack.io") }
         google()
         mavenCentral()
@@ -38,4 +29,3 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "IconsRepository-Plugin"
-


### PR DESCRIPTION
build.gradle.kts:
  - Added import org.jetbrains.kotlin.gradle.dsl.JvmTarget
  - Removed buildToolsVersion = "37.0.0"
  - compileSdk and targetSdk 35 → 34
  - Removed the deprecated android.kotlinOptions { jvmTarget = "17" } block
  - Added top-level kotlin { compilerOptions { jvmTarget.set(JvmTarget.JVM_17) } } block
  - Added packaging.resources.excludes block matching the sibling pattern

settings.gradle.kts:
  - Removed all aliyun mirror declarations from all three blocks
  - AGP 8.12.0 → 8.11.0
  - kotlin-gradle-plugin 2.1.0 → 2.3.0
  - Kept jitpack.io (still needed for com.github.megatronking:svg-generator)