### PR TITLE
ADFA-4035 | Fix sketch checkbox OCR parsing

### DIFF
--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/RegionOcrProcessor.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/RegionOcrProcessor.kt
@@ -22,6 +22,8 @@ class RegionOcrProcessor(
         "switch_off",
         "text_entry_box",
         "dropdown",
+        "checkbox_checked",
+        "checkbox_unchecked",
         "radio_button_checked",
         "radio_button_unchecked",
         "slider",

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/TextAssociator.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/TextAssociator.kt
@@ -12,6 +12,9 @@ import kotlin.math.max
  */
 object TextAssociator {
     private const val OVERLAP_THRESHOLD = 0.6
+    private const val MIN_LINE_TOLERANCE = 12
+    private const val LABEL_FRAGMENT_MAX_GAP_MULTIPLIER = 2
+    private const val MIN_LABEL_FRAGMENT_MAX_GAP = 28
 
     fun assignTextToParents(parents: List<ScaledBox>, texts: List<ScaledBox>, allBoxes: List<ScaledBox>): List<ScaledBox> {
         val consumedTexts = mutableListOf<ScaledBox>()
@@ -86,25 +89,30 @@ object TextAssociator {
         availableTexts: List<ScaledBox>,
         consumedTexts: List<ScaledBox>
     ): List<ScaledBox> {
-        val lineTolerance = max(anchor.h, widget.h).coerceAtLeast(12)
-        val maxGap = max(widget.h * 2, 28)
+        val lineTolerance = max(anchor.h, widget.h).coerceAtLeast(MIN_LINE_TOLERANCE)
+        val maxGap = max(widget.h * LABEL_FRAGMENT_MAX_GAP_MULTIPLIER, MIN_LABEL_FRAGMENT_MAX_GAP)
+
+        val sameLineTexts = availableTexts
+            .asSequence()
+            .filter { candidate -> consumedTexts.none { it.sameGeometryAs(candidate) } }
+            .filter { candidate -> abs(candidate.centerY - anchor.centerY) <= lineTolerance }
+            .sortedBy { it.x }
+            .toList()
 
         val fragments = mutableListOf(anchor)
         var previous = anchor
 
-        while (true) {
-            val next = availableTexts
-                .asSequence()
-                .filter { candidate -> consumedTexts.none { it.sameGeometryAs(candidate) } }
-                .filter { candidate -> fragments.none { it.sameGeometryAs(candidate) } }
-                .filter { abs(it.centerY - anchor.centerY) <= lineTolerance }
-                .filter { it.x >= previous.x + previous.w }
-                .filter { it.x - (previous.x + previous.w) <= maxGap }
-                .minByOrNull { it.x }
-                ?: break
+        for (candidate in sameLineTexts) {
+            if (fragments.any { it.sameGeometryAs(candidate) }) continue
 
-            fragments.add(next)
-            previous = next
+            val previousEndX = previous.x + previous.w
+            val gap = candidate.x - previousEndX
+
+            if (candidate.x < previousEndX) continue
+            if (gap > maxGap) break
+
+            fragments.add(candidate)
+            previous = candidate
         }
 
         return fragments.sortedBy { it.x }

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/TextAssociator.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/TextAssociator.kt
@@ -1,6 +1,5 @@
 package org.appdevforall.codeonthego.computervision.domain
 
-import android.graphics.Rect
 import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
 import org.appdevforall.codeonthego.computervision.utils.TextCleaner.cleanTextPreservingLeadingO
 import org.appdevforall.codeonthego.computervision.utils.TextCleaner.cleanTextStrippingLeadingO
@@ -15,59 +14,52 @@ object TextAssociator {
     private const val OVERLAP_THRESHOLD = 0.6
 
     fun assignTextToParents(parents: List<ScaledBox>, texts: List<ScaledBox>, allBoxes: List<ScaledBox>): List<ScaledBox> {
-        val consumedTexts = mutableSetOf<ScaledBox>()
-        val updatedParents = mutableMapOf<ScaledBox, ScaledBox>()
+        val consumedTexts = mutableListOf<ScaledBox>()
+        val updatedParents = mutableListOf<Pair<ScaledBox, ScaledBox>>()
 
         for (parent in parents) {
             texts.firstOrNull { text ->
-                !consumedTexts.contains(text) &&
-                    Rect(parent.rect).let { intersection ->
-                        intersection.intersect(text.rect) &&
-                            (intersection.width() * intersection.height()).let { intersectionArea ->
-                                val textArea = text.w * text.h
-                                textArea > 0 && (intersectionArea.toFloat() / textArea.toFloat()) > OVERLAP_THRESHOLD
-                            }
-                    }
+                !consumedTexts.any { it.sameGeometryAs(text) } &&
+                    textOverlapRatio(parent, text) > OVERLAP_THRESHOLD
             }?.let {
-                updatedParents[parent] = parent.copy(text = it.text)
+                updatedParents.add(parent to parent.copy(text = it.text))
                 consumedTexts.add(it)
             }
         }
 
         return allBoxes.mapNotNull { box ->
             when {
-                consumedTexts.contains(box) -> null
-                updatedParents.containsKey(box) -> updatedParents[box]
-                else -> box
+                consumedTexts.any { it.sameGeometryAs(box) } -> null
+                else -> updatedParents.firstOrNull { it.first.sameGeometryAs(box) }?.second ?: box
             }
         }
     }
 
     fun assignNearbyTextToWidgets(boxes: List<ScaledBox>, availableTexts: List<ScaledBox>): List<ScaledBox> {
-        val consumedTexts = mutableSetOf<ScaledBox>()
-        val updatedWidgets = mutableMapOf<ScaledBox, ScaledBox>()
+        val consumedTexts = mutableListOf<ScaledBox>()
+        val updatedWidgets = mutableListOf<Pair<ScaledBox, ScaledBox>>()
 
         val labelableWidgets = boxes.filter { isLabelableWidget(it) }.sortedWith(compareBy({ it.y }, { it.x }))
 
         for (widget in labelableWidgets) {
             val nearbyText = availableTexts
                 .asSequence()
-                .filter { it !in consumedTexts }
+                .filter { candidate -> consumedTexts.none { it.sameGeometryAs(candidate) } }
                 .filter { text -> widget.isVerticallyAlignedWith(text, tolerance = max(widget.h * 2.5, 40.0)) }
                 .minByOrNull { text -> widget.calculateProximityScoreTo(text) }
 
             if (nearbyText != null) {
-                val finalText = cleanWidgetText(widget, nearbyText.text)
-                updatedWidgets[widget] = widget.copy(text = finalText)
-                consumedTexts.add(nearbyText)
+                val labelFragments = collectLabelFragments(widget, nearbyText, availableTexts, consumedTexts)
+                val finalText = cleanWidgetText(widget, labelFragments.joinToString(" ") { it.text })
+                updatedWidgets.add(widget to widget.copy(text = finalText))
+                consumedTexts.addAll(labelFragments)
             }
         }
 
         return boxes.mapNotNull { box ->
-            when (box) {
-                in consumedTexts -> null
-                in updatedWidgets -> updatedWidgets[box]
-                else -> box
+            when {
+                consumedTexts.any { it.sameGeometryAs(box) } -> null
+                else -> updatedWidgets.firstOrNull { it.first.sameGeometryAs(box) }?.second ?: box
             }
         }
     }
@@ -88,19 +80,69 @@ object TextAssociator {
         }
     }
 
+    private fun collectLabelFragments(
+        widget: ScaledBox,
+        anchor: ScaledBox,
+        availableTexts: List<ScaledBox>,
+        consumedTexts: List<ScaledBox>
+    ): List<ScaledBox> {
+        val lineTolerance = max(anchor.h, widget.h).coerceAtLeast(12)
+        val maxGap = max(widget.h * 2, 28)
+
+        val fragments = mutableListOf(anchor)
+        var previous = anchor
+
+        while (true) {
+            val next = availableTexts
+                .asSequence()
+                .filter { candidate -> consumedTexts.none { it.sameGeometryAs(candidate) } }
+                .filter { candidate -> fragments.none { it.sameGeometryAs(candidate) } }
+                .filter { abs(it.centerY - anchor.centerY) <= lineTolerance }
+                .filter { it.x >= previous.x + previous.w }
+                .filter { it.x - (previous.x + previous.w) <= maxGap }
+                .minByOrNull { it.x }
+                ?: break
+
+            fragments.add(next)
+            previous = next
+        }
+
+        return fragments.sortedBy { it.x }
+    }
+
     private fun ScaledBox.isVerticallyAlignedWith(other: ScaledBox, tolerance: Double): Boolean {
         return abs(this.centerY - other.centerY) < tolerance
     }
 
     private fun ScaledBox.calculateProximityScoreTo(other: ScaledBox): Double {
-        val dx = this.rect.horizontalDistanceTo(other.rect).toDouble()
+        val dx = this.horizontalDistanceTo(other).toDouble()
         val dy = abs(this.centerY - other.centerY).toDouble()
         return (dx * dx) + (dy * dy * 5)
     }
 
-    private fun Rect.horizontalDistanceTo(other: Rect): Int = when {
-        this.right < other.left -> other.left - this.right
-        this.left > other.right -> this.left - other.right
+    private fun textOverlapRatio(parent: ScaledBox, text: ScaledBox): Float {
+        val intersectionWidth = minOf(parent.x + parent.w, text.x + text.w) - maxOf(parent.x, text.x)
+        val intersectionHeight = minOf(parent.y + parent.h, text.y + text.h) - maxOf(parent.y, text.y)
+        if (intersectionWidth <= 0 || intersectionHeight <= 0) return 0f
+
+        val textArea = text.w * text.h
+        if (textArea <= 0) return 0f
+
+        return (intersectionWidth * intersectionHeight).toFloat() / textArea.toFloat()
+    }
+
+    private fun ScaledBox.horizontalDistanceTo(other: ScaledBox): Int = when {
+        this.x + this.w < other.x -> other.x - (this.x + this.w)
+        this.x > other.x + other.w -> this.x - (other.x + other.w)
         else -> 0
+    }
+
+    private fun ScaledBox.sameGeometryAs(other: ScaledBox): Boolean {
+        return label == other.label &&
+            text == other.text &&
+            x == other.x &&
+            y == other.y &&
+            w == other.w &&
+            h == other.h
     }
 }

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/grammar/AttributeValidator.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/grammar/AttributeValidator.kt
@@ -37,6 +37,21 @@ object DimensionValidator : AttributeValidator {
     }
 }
 
+object ColorValidator : AttributeValidator {
+    private val hexColorRegex = Regex("^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$")
+    private val androidColorRegex = Regex("^@android:color/[A-Za-z][A-Za-z0-9_]*$")
+    private val projectColorRegex = Regex("^@color/[A-Za-z][A-Za-z0-9_]*$")
+
+    override fun validate(rawValue: String): String? {
+        val trimmed = rawValue.trim()
+        return trimmed.takeIf {
+            hexColorRegex.matches(it) ||
+                androidColorRegex.matches(it) ||
+                projectColorRegex.matches(it)
+        }
+    }
+}
+
 class SpDimensionRangeValidator(
     private val minSp: Int,
     private val maxSp: Int

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/grammar/WidgetGrammar.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/grammar/WidgetGrammar.kt
@@ -28,15 +28,15 @@ interface LayoutGrammar : WidgetGrammar {
             AttributeKey.LAYOUT_WEIGHT.xmlName to PassThroughValidator,
             AttributeKey.PADDING.xmlName to DimensionValidator,
             AttributeKey.VISIBILITY.xmlName to CategoricalValidator(VisibilityValueSet.values),
-            AttributeKey.BACKGROUND.xmlName to PassThroughValidator,
-            AttributeKey.BACKGROUND_TINT.xmlName to PassThroughValidator
+            AttributeKey.BACKGROUND.xmlName to ColorValidator,
+            AttributeKey.BACKGROUND_TINT.xmlName to ColorValidator
         )
 }
 
 interface TextGrammar : LayoutGrammar {
     override val attributes: Map<String, AttributeValidator>
         get() = super.attributes + mapOf(
-            AttributeKey.TEXT_COLOR.xmlName to PassThroughValidator,
+            AttributeKey.TEXT_COLOR.xmlName to ColorValidator,
             AttributeKey.TEXT_SIZE.xmlName to PassThroughValidator,
             AttributeKey.TEXT_STYLE.xmlName to PassThroughValidator,
             AttributeKey.TEXT_ALIGNMENT.xmlName to PassThroughValidator,

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/AttributeModels.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/AttributeModels.kt
@@ -88,7 +88,21 @@ enum class AttributeKey(
     CONTENT_DESCRIPTION("android:contentDescription", listOf("contentdescription", "content_description")),
 
     TEXT_SIZE("android:textSize", listOf("textsize", "text_size"), ValueType.SP_DIMENSION),
-    TEXT_COLOR("android:textColor", listOf("textcolor", "text_color", "color", "text_colar", "textcolar"), ValueType.COLOR),
+    TEXT_COLOR(
+        "android:textColor",
+        listOf(
+            "textcolor",
+            "text_color",
+            "text_calar",
+            "text_colar",
+            "text_colour",
+            "textcalar",
+            "textcolar",
+            "textcolour",
+            "color"
+        ),
+        ValueType.COLOR
+    ),
     TEXT_STYLE("android:textStyle", listOf("textstyle", "text_style"), ValueType.TEXT_STYLE),
     TEXT_ALIGNMENT("android:textAlignment", listOf("textalignment", "text_alignment")),
     TEXT_ALL_CAPS("android:textAllCaps", listOf("textallcaps", "text_all_caps")),

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/FuzzyAttributeParser.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/FuzzyAttributeParser.kt
@@ -9,6 +9,10 @@ object FuzzyAttributeParser {
     private val grammarValidator = UiGrammarValidator()
     private const val PIPE_DELIMITER = "|"
     private val multipleUnderscoresRegex = Regex("_+")
+    private val textColorKeyPhraseRegex = Regex(
+        "\\btext\\s*[-_ ]\\s*(?:colou?r|calar|colar)\\b",
+        RegexOption.IGNORE_CASE
+    )
     private val inputTypeValues = InputTypeValueSet.values.map { it.lowercase() }.toSet()
     private val sanitizer = OcrSanitizerFactory.createDefaultSanitizer()
 
@@ -35,7 +39,7 @@ object FuzzyAttributeParser {
     fun parse(annotation: String?, tag: String): Map<String, String> {
         if (annotation.isNullOrBlank()) return emptyMap()
 
-        val normalizedInput = annotation.replace(Regex("\\s+:"), ":")
+        val normalizedInput = normalizeOcrKeyPhrases(annotation.replace(Regex("\\s+:"), ":"))
         val tokens = tokenizeAnnotation(normalizedInput)
 
         val rawAttributes = mapTokensToAttributes(tokens, tag)
@@ -48,10 +52,35 @@ object FuzzyAttributeParser {
         val sanitized = sanitizer.sanitize(annotation)
 
         return if (sanitized.contains(PIPE_DELIMITER)) {
-            sanitized.split(PIPE_DELIMITER).map { it.trim() }.filter { it.isNotEmpty() }
+            sanitized.split(PIPE_DELIMITER)
+                .flatMap(::tokenizeDelimitedChunk)
+                .filter { it.isNotEmpty() }
         } else {
             sanitized.split(Regex("[:;]|\\s+")).map { it.trim() }.filter { it.isNotEmpty() }
         }
+    }
+
+    private fun normalizeOcrKeyPhrases(annotation: String): String {
+        return textColorKeyPhraseRegex.replace(annotation, "textcolor")
+    }
+
+    private fun tokenizeDelimitedChunk(chunk: String): List<String> {
+        val trimmed = chunk.trim()
+        if (trimmed.isEmpty()) return emptyList()
+
+        val delimiterIndex = trimmed.indexOfFirst { it == ':' || it == ';' }
+        if (delimiterIndex >= 0) {
+            val key = trimmed.substring(0, delimiterIndex).trim()
+            val value = trimmed.substring(delimiterIndex + 1).trim()
+            return listOf(key, value).filter { it.isNotEmpty() }
+        }
+
+        val firstSpace = trimmed.indexOfFirst { it.isWhitespace() }
+        if (firstSpace < 0) return listOf(trimmed)
+
+        val key = trimmed.substring(0, firstSpace).trim()
+        val value = trimmed.substring(firstSpace + 1).trim()
+        return listOf(key, value).filter { it.isNotEmpty() }
     }
 
     private fun mapTokensToAttributes(tokens: List<String>, tag: String): Map<String, String> {
@@ -112,6 +141,7 @@ object FuzzyAttributeParser {
     private fun fuzzyMatchKey(rawKey: String): AttributeKey? {
         val normalizedKey = rawKey.lowercase()
             .replace("-", "_")
+            .replace(Regex("\\s+"), "_")
             .replace(".", "_")
             .replace(multipleUnderscoresRegex, "_")
             .replace(Regex("lay[ao0]ut"), "layout")
@@ -120,7 +150,7 @@ object FuzzyAttributeParser {
         val exactMatch = AttributeKey.findByAlias(normalizedKey)
         if (exactMatch != null) return exactMatch
 
-        if (normalizedKey.length < 2) return null
+        if (normalizedKey.length <= 2) return null
 
         val threshold = when {
             normalizedKey.length <= 3 -> 65

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/utils/TextCleaner.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/utils/TextCleaner.kt
@@ -27,6 +27,7 @@ object TextCleaner {
             .replace(Regex("^[\\[\\]()●○□☑✓-]+\\s*"), "")
 
         cleanedText = cleanedText.replace(Regex("^[DT]?opti[oa]n", RegexOption.IGNORE_CASE), "Option")
+        cleanedText = cleanedText.replace(Regex("^joption", RegexOption.IGNORE_CASE), "Option")
         cleanedText = cleanedText.replace(Regex("^pti[oa]n", RegexOption.IGNORE_CASE), "Option")
         cleanedText = cleanedText.replace(Regex("^optton", RegexOption.IGNORE_CASE), "Option")
 

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/CheckboxLabelLayoutTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/CheckboxLabelLayoutTest.kt
@@ -1,0 +1,49 @@
+package org.appdevforall.codeonthego.computervision.domain
+
+import android.graphics.Rect
+import org.appdevforall.codeonthego.computervision.domain.model.LayoutItem
+import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+import org.appdevforall.codeonthego.computervision.domain.xml.LayoutRenderer
+import org.appdevforall.codeonthego.computervision.domain.xml.XmlContext
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CheckboxLabelLayoutTest {
+
+    @Test
+    fun `consumed numeric suffix does not render as extra TextView`() {
+        val checkbox = box("checkbox_checked", "", x = 0, y = 0, w = 20, h = 20)
+        val option = box("text", "Option", x = 28, y = 1, w = 48, h = 18)
+        val one = box("text", "1", x = 84, y = 1, w = 8, h = 18)
+
+        val associated = TextAssociator.assignNearbyTextToWidgets(
+            boxes = listOf(checkbox, option, one),
+            availableTexts = listOf(option, one)
+        )
+        val layoutItems = LayoutTreeBuilder.buildLayoutTree(associated)
+        val context = XmlContext()
+        val renderer = LayoutRenderer(context, annotations = emptyMap())
+
+        layoutItems.forEach { renderer.render(it) }
+
+        val xml = context.toString()
+        assertTrue(xml, xml.contains("""android:text="Option 1""""))
+        assertFalse(xml, xml.contains("<TextView"))
+        assertTrue(layoutItems.single() is LayoutItem.CheckboxGroup)
+    }
+
+    private fun box(label: String, text: String, x: Int, y: Int, w: Int, h: Int): ScaledBox {
+        return ScaledBox(
+            label = label,
+            text = text,
+            x = x,
+            y = y,
+            w = w,
+            h = h,
+            centerX = x + w / 2,
+            centerY = y + h / 2,
+            rect = Rect(x, y, x + w, y + h)
+        )
+    }
+}

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParserTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParserTest.kt
@@ -91,6 +91,69 @@ class FuzzyAttributeParserTest {
     }
 
     @Test
+    fun `textColor black is normalized to valid color`() {
+        val annotation = "textcolor: black | width: 100dp"
+        val result = FuzzyAttributeParser.parse(annotation, "CheckBox")
+
+        assertEquals("#000000", result["android:textColor"])
+    }
+
+    @Test
+    fun `textColor OCR key variants keep black as local color value`() {
+        val annotations = listOf(
+            "textcolor: black",
+            "text color: black",
+            "text-color: black",
+            "text_color: black",
+            "textcalar: black",
+            "text calar:black",
+            "text calar: black",
+            "id: cb_group_1 textcolor: black",
+            "id: co group1 text: Sclect.optian textcalar: black",
+            "layout-width: 200dp layout-height: wrap-content id: cb_group_1 text: select_option textcolor: black"
+        )
+
+        annotations.forEach { annotation ->
+            val result = FuzzyAttributeParser.parse(annotation, "CheckBox")
+
+            assertEquals("Failed for annotation: $annotation", "#000000", result["android:textColor"])
+            assertTrue("textColor must not use group1 for annotation: $annotation", result["android:textColor"] != "group1")
+        }
+    }
+
+    @Test
+    fun `invalid textColor is omitted`() {
+        val annotation = "textcolor: group1 | width: 100dp"
+        val result = FuzzyAttributeParser.parse(annotation, "CheckBox")
+
+        assertNull(result["android:textColor"])
+        assertEquals("100dp", result["android:layout_width"])
+    }
+
+    @Test
+    fun `invalid textColor OCR variants are omitted`() {
+        val annotations = listOf(
+            "textcolor: group1",
+            "textcalar: group1"
+        )
+
+        annotations.forEach { annotation ->
+            val result = FuzzyAttributeParser.parse(annotation, "CheckBox")
+
+            assertNull("Expected invalid color to be omitted for annotation: $annotation", result["android:textColor"])
+        }
+    }
+
+    @Test
+    fun `android and project color resources are valid text colors`() {
+        val androidColor = FuzzyAttributeParser.parse("textcolor: @android:color/black | width: 100dp", "CheckBox")
+        val projectColor = FuzzyAttributeParser.parse("textcolor: @color/primary_text | width: 100dp", "CheckBox")
+
+        assertEquals("@android:color/black", androidColor["android:textColor"])
+        assertEquals("@color/primary_text", projectColor["android:textColor"])
+    }
+
+    @Test
     fun `OCR garbled keys are fuzzy matched via delimited`() {
         val annotation = "wldth: 100dp | hejght: 80dp"
         val result = FuzzyAttributeParser.parse(annotation, "Button")

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/TextAssociatorTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/TextAssociatorTest.kt
@@ -1,0 +1,52 @@
+package org.appdevforall.codeonthego.computervision.domain
+
+import android.graphics.Rect
+import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class TextAssociatorTest {
+
+    @Test
+    fun `label fragments are merged and consumed for checkbox`() {
+        val checkbox = box("checkbox_checked", "", x = 0, y = 0, w = 20, h = 20)
+        val option = box("text", "Option", x = 28, y = 1, w = 48, h = 18)
+        val one = box("text", "1", x = 84, y = 1, w = 8, h = 18)
+
+        val result = TextAssociator.assignNearbyTextToWidgets(
+            boxes = listOf(checkbox, option, one),
+            availableTexts = listOf(option, one)
+        )
+
+        assertEquals("Option 1", result.single { it.label == "checkbox_checked" }.text)
+        assertFalse(result.any { it.label == "text" && it.text == "1" })
+    }
+
+    @Test
+    fun `checkbox label OCR artifact is normalized conservatively`() {
+        val checkbox = box("checkbox_unchecked", "", x = 0, y = 0, w = 20, h = 20)
+        val label = box("text", "Joption 2", x = 28, y = 1, w = 80, h = 18)
+
+        val result = TextAssociator.assignNearbyTextToWidgets(
+            boxes = listOf(checkbox, label),
+            availableTexts = listOf(label)
+        )
+
+        assertEquals("Option 2", result.single { it.label == "checkbox_unchecked" }.text)
+    }
+
+    private fun box(label: String, text: String, x: Int, y: Int, w: Int, h: Int): ScaledBox {
+        return ScaledBox(
+            label = label,
+            text = text,
+            x = x,
+            y = y,
+            w = w,
+            h = h,
+            centerX = x + w / 2,
+            centerY = y + h / 2,
+            rect = Rect(x, y, x + w, y + h)
+        )
+    }
+}

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/xml/LayoutRendererTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/xml/LayoutRendererTest.kt
@@ -3,6 +3,8 @@ package org.appdevforall.codeonthego.computervision.domain.xml
 import android.graphics.Rect
 import org.appdevforall.codeonthego.computervision.domain.model.LayoutItem
 import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -28,6 +30,35 @@ class LayoutRendererTest {
         assertTrue(xml.contains("""android:id="@+id/cb_group_2_a""""))
         assertTrue(xml.contains("""android:id="@+id/cb_group_2_b""""))
         assertTrue(!xml.contains("cbgraup2"))
+    }
+
+    @Test
+    fun `checkbox group noisy textColor annotation emits valid textColor without losing option labels`() {
+        val first = checkboxBox(y = 0, text = "Option 1", checked = true)
+        val second = checkboxBox(y = 20, text = "Option 2")
+        val third = checkboxBox(y = 40, text = "Option 3", checked = true)
+        val context = XmlContext()
+
+        val renderer = LayoutRenderer(
+            context = context,
+            annotations = mapOf(
+                first to "layout-width: 200dP layout-height. content wrap id: co group1 text: Sclect.optian textcalar: black"
+            )
+        )
+
+        renderer.render(LayoutItem.CheckboxGroup(listOf(first, second, third), "vertical"))
+
+        val xml = context.toString()
+
+        assertTrue(xml.contains("""android:id="@+id/cb_group_1_a""""))
+        assertTrue(xml.contains("""android:id="@+id/cb_group_1_b""""))
+        assertTrue(xml.contains("""android:id="@+id/cb_group_1_c""""))
+        assertTrue(xml.contains("""android:text="Option 1""""))
+        assertTrue(xml.contains("""android:text="Option 2""""))
+        assertTrue(xml.contains("""android:text="Option 3""""))
+        assertEquals(3, Regex("""android:textColor="#000000"""").findAll(xml).count())
+        assertFalse(xml.contains("""android:textColor="group1""""))
+        assertFalse(xml.contains("<TextView"))
     }
 
     @Test


### PR DESCRIPTION
## Description

Improves the Sketch to UI plugin generation for checkbox groups by handling noisy OCR output more reliably.

This update fixes cases where checkbox labels were split into separate text nodes, OCR artifacts like `Joption` were generated, and noisy `textColor` annotations such as `textcalar: black` were not correctly converted into valid Android XML.

## Details

* Added checkbox widgets to region OCR processing.
* Merged nearby checkbox label fragments such as `Option` + `1` into `Option 1`.
* Prevented consumed label fragments from being rendered as extra `TextView` nodes.
* Normalized common checkbox label OCR artifacts, including `Joption` → `Option`.
* Added stricter parsing support for OCR variants of `textColor`.
* Added color validation for `android:textColor`, `android:background`, and `app:backgroundTint`.
* Prevented invalid values like `group1` from being emitted as Android color attributes.
* Added tests for checkbox label association, noisy `textColor` parsing, invalid color rejection, and checkbox group rendering.


https://github.com/user-attachments/assets/1b1446cd-ccd7-40c3-ac18-60ded523a898


## Ticket

[ADFA-4035](https://appdevforall.atlassian.net/browse/ADFA-4035)

## Observation

The fix was validated with the original sketch scenario. The generated XML now preserves `Option 1`, `Option 2`, and `Option 3`, keeps checked states, avoids extra `TextView` output, and correctly emits `android:textColor="#000000"` for the checkbox group.

[ADFA-4035]: https://appdevforall.atlassian.net/browse/ADFA-4035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ