### PR TITLE
ADFA-4038 | Fix sketch-to-UI metadata detection

### DIFF
--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/DetectionMerger.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/DetectionMerger.kt
@@ -3,14 +3,17 @@ package org.appdevforall.codeonthego.computervision.domain
 import android.graphics.RectF
 import com.google.mlkit.vision.text.Text
 import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
+import org.appdevforall.codeonthego.computervision.domain.model.SketchRegion
+import org.appdevforall.codeonthego.computervision.utils.MetadataDetector
 import org.appdevforall.codeonthego.computervision.utils.OcrTextAssembler.joinElementsWithTolerance
 
 class DetectionMerger(
     private val enrichedComponents: List<DetectionResult>,
     private val remainingYoloDetections: List<DetectionResult>,
-    private val fullImageTextBlocks: List<Text.TextBlock>
+    private val fullImageTextBlocks: List<Text.TextBlock>,
+    private val leftBoundPx: Float? = null,
+    private val rightBoundPx: Float? = null
 ) {
-
     private val containerLabels = setOf("card", "toolbar")
 
     fun merge(): List<DetectionResult> {
@@ -25,14 +28,17 @@ class DetectionMerger(
             val candidates = fullImageTextBlocks.filter { it !in usedTextBlocks }
             for (textBlock in candidates) {
                 val textBox = textBlock.boundingBox?.let { RectF(it) } ?: continue
-                if (container.boundingBox.contains(textBox)) {
+                val region = classify(textBox)
+                val isCanvasText = region == null || region == SketchRegion.CANVAS
+                if (isCanvasText && container.boundingBox.contains(textBox)) {
                     finalDetections.add(
                         DetectionResult(
                             boundingBox = textBox,
                             label = "text",
                             score = 0.99f,
                             text = textBlock.text.replace("\n", " "),
-                            isYolo = false
+                            isYolo = false,
+                            region = region
                         )
                     )
                     usedTextBlocks.add(textBlock)
@@ -45,12 +51,18 @@ class DetectionMerger(
             .flatMap { it.lines }
             .mapNotNull { line ->
                 line.boundingBox?.let { box ->
+                    val bounds = RectF(box)
+                    val region = classify(bounds)
+                    val text = joinElementsWithTolerance(line)
+                    val resolvedRegion = resolveCrossBoundaryTextRegion(region, text)
+                        ?: return@mapNotNull null
                     DetectionResult(
-                        boundingBox = RectF(box),
+                        boundingBox = bounds,
                         label = "text",
-                        score = 0.99f,
-                        text = joinElementsWithTolerance(line),
-                        isYolo = false
+                        score = if (resolvedRegion != SketchRegion.CANVAS) 0.98f else 0.99f,
+                        text = text,
+                        isYolo = false,
+                        region = resolvedRegion
                     )
                 }
             }
@@ -58,5 +70,20 @@ class DetectionMerger(
         finalDetections.addAll(orphanDetections)
 
         return finalDetections
+    }
+
+    private fun classify(bounds: RectF): SketchRegion? {
+        val left = leftBoundPx ?: return null
+        val right = rightBoundPx ?: return null
+        return SketchRegionClassifier.classify(bounds, left, right)
+    }
+
+    private fun resolveCrossBoundaryTextRegion(region: SketchRegion?, text: String): SketchRegion? {
+        if (region != SketchRegion.CROSS_BOUNDARY) return region
+        return if (MetadataDetector.isCanvasMetadata(text) || WidgetTagParser.isTagSequence(text)) {
+            null
+        } else {
+            SketchRegion.CANVAS
+        }
     }
 }

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/MarginAnnotationParser.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/MarginAnnotationParser.kt
@@ -1,11 +1,11 @@
 package org.appdevforall.codeonthego.computervision.domain
 
 import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
+import org.appdevforall.codeonthego.computervision.domain.model.SketchRegion
 import org.appdevforall.codeonthego.computervision.utils.MetadataDetector
 import kotlin.math.abs
 
 object MarginAnnotationParser {
-
     /**
      * Extracts canvas UI elements and parses margin annotations, linking them together.
      * * @param detections The full list of detections from YOLO and OCR.
@@ -52,15 +52,46 @@ object MarginAnnotationParser {
         val rightMargin = mutableListOf<DetectionResult>()
 
         for (detection in detections) {
+            if (detection.isInvalidWidgetTag()) {
+                continue
+            }
+            when (detection.region) {
+                SketchRegion.LEFT_METADATA -> {
+                    leftMargin.add(detection)
+                    continue
+                }
+                SketchRegion.RIGHT_METADATA -> {
+                    rightMargin.add(detection)
+                    continue
+                }
+                SketchRegion.CANVAS -> {
+                    canvas.add(detection)
+                    continue
+                }
+                SketchRegion.CROSS_BOUNDARY -> {
+                    if (detection.isRenderableCrossBoundaryText()) {
+                        canvas.add(detection)
+                    }
+                    continue
+                }
+                null -> Unit
+            }
+
             val isMetadata = MetadataDetector.isCanvasMetadata(detection.text)
             val centerX = centerX(detection)
 
-            when {
-                isMetadata && centerX < (imageWidth / 2f) -> leftMargin.add(detection)
-                isMetadata && centerX >= (imageWidth / 2f) -> rightMargin.add(detection)
-                centerX > leftMarginPx && centerX < rightMarginPx -> canvas.add(detection)
-                centerX <= leftMarginPx -> leftMargin.add(detection)
-                else -> rightMargin.add(detection)
+            val assignedRegion = when {
+                isMetadata && centerX < (imageWidth / 2f) -> SketchRegion.LEFT_METADATA
+                isMetadata && centerX >= (imageWidth / 2f) -> SketchRegion.RIGHT_METADATA
+                centerX > leftMarginPx && centerX < rightMarginPx -> SketchRegion.CANVAS
+                centerX <= leftMarginPx -> SketchRegion.LEFT_METADATA
+                else -> SketchRegion.RIGHT_METADATA
+            }
+            when (assignedRegion) {
+                SketchRegion.LEFT_METADATA -> leftMargin.add(detection)
+                SketchRegion.RIGHT_METADATA -> rightMargin.add(detection)
+                SketchRegion.CANVAS -> canvas.add(detection)
+                SketchRegion.CROSS_BOUNDARY -> Unit
             }
         }
 
@@ -72,7 +103,10 @@ object MarginAnnotationParser {
      */
     private fun extractCanvasTags(canvasDetections: List<DetectionResult>): List<Pair<String, DetectionResult>> {
         return canvasDetections.mapNotNull { det ->
-            WidgetTagParser.extractTag(det.text)?.let { (tag, _) -> tag to det }
+            if (!WidgetTagParser.isTag(det.text)) return@mapNotNull null
+            WidgetTagParser.extractTag(det.text)?.let { (tag, _) ->
+                tag to det
+            }
         }
     }
 
@@ -132,7 +166,7 @@ object MarginAnnotationParser {
 
         fun saveCurrentBlock() {
             if (currentTag != null) {
-                blocks.explicitAnnotations[currentTag!!] = currentText.toString().trim()
+                blocks.addExplicitAnnotation(currentTag!!, currentText.toString().trim())
             } else if (currentText.isNotBlank()) {
                 blocks.implicitBlocks.add(ParsedBlock(currentText.toString().trim(), blockStartY))
             }
@@ -153,11 +187,11 @@ object MarginAnnotationParser {
 
                 val trailing = extraction.second?.trim()
                 if (!trailing.isNullOrBlank() && WidgetTagParser.normalizeTagText(trailing) != currentTag) {
-                    currentText.append(trailing).append(" ")
+                    currentText.appendAnnotationFragment(trailing)
                 }
             } else {
                 if (currentText.isEmpty()) blockStartY = centerY(det)
-                currentText.append(text).append(" ")
+                currentText.appendAnnotationFragment(text)
             }
         }
         saveCurrentBlock()
@@ -222,10 +256,31 @@ object MarginAnnotationParser {
     private data class GroupedBlocks(
         val explicitAnnotations: MutableMap<String, String> = mutableMapOf(),
         val implicitBlocks: MutableList<ParsedBlock> = mutableListOf()
-    )
+    ) {
+        fun addExplicitAnnotation(tag: String, text: String) {
+            if (text.isBlank()) return
+            explicitAnnotations.merge(tag, text) { existing, newText -> "$existing | $newText" }
+        }
+    }
 
     private data class ParsedBlock(
         val annotationText: String,
         val centerY: Float
     )
+
+    private fun StringBuilder.appendAnnotationFragment(text: String) {
+        if (isNotBlank()) append(" | ")
+        append(text)
+    }
+
+    private fun DetectionResult.isInvalidWidgetTag(): Boolean {
+        return label == "widget_tag" && WidgetTagParser.extractTag(text) == null
+    }
+
+    private fun DetectionResult.isRenderableCrossBoundaryText(): Boolean {
+        return label == "text" &&
+            text.isNotBlank() &&
+            !MetadataDetector.isCanvasMetadata(text) &&
+            !WidgetTagParser.isTagSequence(text)
+    }
 }

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/RegionOcrProcessor.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/RegionOcrProcessor.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import org.appdevforall.codeonthego.computervision.data.source.OcrSource
 import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
+import org.appdevforall.codeonthego.computervision.domain.model.SketchRegion
 import org.appdevforall.codeonthego.computervision.utils.BitmapUtils
 import org.appdevforall.codeonthego.computervision.utils.OcrTextAssembler
 
@@ -91,11 +92,11 @@ class RegionOcrProcessor(
         val results = mutableListOf<DetectionResult>()
 
         val leftRect = RectF(0f, 0f, width * leftGuidePct, height)
-        results.addAll(ocrCroppedRegion(bitmap, leftRect, 0f))
+        results.addAll(ocrCroppedRegion(bitmap, leftRect, 0f, SketchRegion.LEFT_METADATA))
 
         val rightOffsetX = width * rightGuidePct
         val rightRect = RectF(rightOffsetX, 0f, width, height)
-        results.addAll(ocrCroppedRegion(bitmap, rightRect, rightOffsetX))
+        results.addAll(ocrCroppedRegion(bitmap, rightRect, rightOffsetX, SketchRegion.RIGHT_METADATA))
 
         return results
     }
@@ -103,7 +104,8 @@ class RegionOcrProcessor(
     private suspend fun ocrCroppedRegion(
         bitmap: Bitmap,
         rect: RectF,
-        offsetX: Float
+        offsetX: Float,
+        region: SketchRegion
     ): List<DetectionResult> {
         val crop = BitmapUtils.cropRegion(bitmap, rect)
         if (crop === bitmap) return emptyList()
@@ -122,7 +124,8 @@ class RegionOcrProcessor(
                             label = "text",
                             score = 0.99f,
                             text = OcrTextAssembler.joinElementsWithTolerance(line),
-                            isYolo = false
+                            isYolo = false,
+                            region = region
                         )
                     }
                 }

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/SketchRegionClassifier.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/SketchRegionClassifier.kt
@@ -1,0 +1,26 @@
+package org.appdevforall.codeonthego.computervision.domain
+
+import android.graphics.RectF
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
+import org.appdevforall.codeonthego.computervision.domain.model.SketchRegion
+
+object SketchRegionClassifier {
+    fun classify(bounds: RectF, leftBoundPx: Float, rightBoundPx: Float): SketchRegion {
+        return when {
+            bounds.right < leftBoundPx -> SketchRegion.LEFT_METADATA
+            bounds.left > rightBoundPx -> SketchRegion.RIGHT_METADATA
+            bounds.left >= leftBoundPx && bounds.right <= rightBoundPx -> SketchRegion.CANVAS
+            else -> SketchRegion.CROSS_BOUNDARY
+        }
+    }
+
+    fun classifyDetections(
+        detections: List<DetectionResult>,
+        leftBoundPx: Float,
+        rightBoundPx: Float
+    ): List<DetectionResult> {
+        return detections.map { detection ->
+            detection.copy(region = classify(detection.boundingBox, leftBoundPx, rightBoundPx))
+        }
+    }
+}

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetAnnotationMatcher.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetAnnotationMatcher.kt
@@ -1,6 +1,8 @@
 package org.appdevforall.codeonthego.computervision.domain
 
 import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+import java.util.Collections
+import java.util.IdentityHashMap
 
 class WidgetAnnotationMatcher {
     internal fun matchAnnotationsToElements(
@@ -8,8 +10,8 @@ class WidgetAnnotationMatcher {
         uiElements: List<ScaledBox>,
         annotations: Map<String, String>
     ): Map<ScaledBox, String> {
-        val finalAnnotations = mutableMapOf<ScaledBox, String>()
-        val claimedWidgets = mutableSetOf<ScaledBox>()
+        val finalAnnotations = IdentityHashMap<ScaledBox, String>()
+        val claimedWidgets = Collections.newSetFromMap(IdentityHashMap<ScaledBox, Boolean>())
 
         val deduplicatedTags = canvasTags
             .distinctBy { WidgetTagParser.normalizeTagText(it.text) }
@@ -63,6 +65,10 @@ class WidgetAnnotationMatcher {
     }
 
     internal fun isTag(text: String): Boolean = WidgetTagParser.isTag(text)
+
+    internal fun isTagLikeText(text: String): Boolean {
+        return WidgetTagParser.isTag(text) || WidgetTagParser.isTagSequence(text)
+    }
 
     private fun getTagType(tag: String): String? {
         return when {

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetTagParser.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetTagParser.kt
@@ -21,6 +21,11 @@ internal object WidgetTagParser {
         return normalizeTagText(cleaned).matches(tagRegex)
     }
 
+    fun isTagSequence(text: String): Boolean {
+        val tokens = text.trim().split(Regex("\\s+")).filter { it.isNotBlank() }
+        return tokens.isNotEmpty() && tokens.all(::isTag)
+    }
+
     private fun parseTagParts(match: MatchResult): Pair<String, String>? {
         val rawPrefix = match.groupValues[1]
         val prefix = normalizePrefix(rawPrefix)

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/YoloToXmlConverter.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/YoloToXmlConverter.kt
@@ -2,6 +2,7 @@ package org.appdevforall.codeonthego.computervision.domain
 
 import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
 import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+import org.appdevforall.codeonthego.computervision.domain.model.SketchRegion
 import org.appdevforall.codeonthego.computervision.domain.xml.AndroidXmlGenerator
 import org.appdevforall.codeonthego.computervision.utils.MetadataDetector
 import org.appdevforall.codeonthego.computervision.utils.buildPlaceholderOverrides
@@ -11,7 +12,6 @@ class YoloToXmlConverter(
     private val annotationMatcher: WidgetAnnotationMatcher,
     private val xmlGenerator: AndroidXmlGenerator
 ) {
-
     fun generateXmlLayout(
         detections: List<DetectionResult>,
         annotations: Map<String, String>,
@@ -39,12 +39,13 @@ class YoloToXmlConverter(
 
         // 6. Match margin annotations with the extracted UI elements
         val finalAnnotations = annotationMatcher.matchAnnotationsToElements(canvasTags, uiElements, annotations)
+        val filteredUiElements = filterLikelyDuplicateImagePlaceholders(uiElements, finalAnnotations)
 
         // 7. Sort boxes top-to-bottom, left-to-right for sequential XML rendering
-        val sortedBoxes = uiElements.sortedWith(compareBy({ it.y }, { it.x }))
+        val sortedBoxes = filteredUiElements.sortedWith(compareBy({ it.y }, { it.x }))
 
         // 8. Prepare local drawable resources overrides for image placeholders
-        val selectedImageOverrides = uiElements.buildPlaceholderOverrides(selectedImagesByPlaceholderId)
+        val selectedImageOverrides = filteredUiElements.buildPlaceholderOverrides(selectedImagesByPlaceholderId)
 
         // 9. Generate final XML output
         return xmlGenerator.buildXml(
@@ -58,7 +59,9 @@ class YoloToXmlConverter(
 
     private fun extractUiCandidates(detections: List<DetectionResult>): List<DetectionResult> {
         return detections
+            .filterNot { it.isInvalidWidgetTag() }
             .filter { (it.isYolo || it.label == "text") && it.label != "widget_tag" }
+            .filter { it.isCanvasRenderable() }
             .filterNot { MetadataDetector.isMetadataDetection(it.label, it.text) }
             .distinctBy {
                 if (it.label.startsWith("switch")) {
@@ -85,19 +88,20 @@ class YoloToXmlConverter(
 
     private fun associateTextToWidgets(scaledBoxes: List<ScaledBox>): List<ScaledBox> {
         val parents = scaledBoxes.filter { it.label != "text" }
-        val initialTexts = scaledBoxes.filter { it.label == "text" && !annotationMatcher.isTag(it.text) }
+        val initialTexts = scaledBoxes.filter { it.label == "text" && !annotationMatcher.isTagLikeText(it.text) }
 
         val textAssignedBoxes = TextAssociator.assignTextToParents(parents, initialTexts, scaledBoxes)
-        val remainingTexts = textAssignedBoxes.filter { it.label == "text" && !annotationMatcher.isTag(it.text) }
+        val remainingTexts = textAssignedBoxes.filter { it.label == "text" && !annotationMatcher.isTagLikeText(it.text) }
 
         return TextAssociator.assignNearbyTextToWidgets(textAssignedBoxes, remainingTexts)
     }
 
     private fun finalizeUiElements(boxes: List<ScaledBox>): List<ScaledBox> {
-        return boxes.filter {
+        return boxes.filter { box ->
             // Keep the widget if it's not pure text, or if it is text but not recognized as a tag.
-            (it.label != "text" || !annotationMatcher.isTag(it.text)) && 
-            !MetadataDetector.isMetadataDetection(it.label, it.text)
+            val keep = (box.label != "text" || !annotationMatcher.isTagLikeText(box.text)) &&
+                !MetadataDetector.isMetadataDetection(box.label, box.text)
+            keep
         }
     }
 
@@ -109,10 +113,62 @@ class YoloToXmlConverter(
         targetHeight: Int
     ): List<ScaledBox> {
         val widgetTags = detections.filter { 
-            it.label == "widget_tag" || (!it.isYolo && annotationMatcher.isTag(it.text)) 
+            (it.region == null || it.region == SketchRegion.CANVAS) &&
+                ((it.label == "widget_tag" && WidgetTagParser.extractTag(it.text) != null) ||
+                    (!it.isYolo && annotationMatcher.isTag(it.text)))
         }
-        return widgetTags.map { 
-            DetectionScaler.scale(it, sourceWidth, sourceHeight, targetWidth, targetHeight)
+        return widgetTags.map { detection ->
+            DetectionScaler.scale(detection, sourceWidth, sourceHeight, targetWidth, targetHeight)
+        }
+    }
+
+    private fun filterLikelyDuplicateImagePlaceholders(
+        uiElements: List<ScaledBox>,
+        annotations: Map<ScaledBox, String>
+    ): List<ScaledBox> {
+        val annotatedImages = uiElements
+            .filter { it.isImagePlaceholder() && annotations.containsKey(it) }
+        if (annotatedImages.isEmpty()) return uiElements
+
+        return uiElements.filterNot { box ->
+            box.isImagePlaceholder() &&
+                !annotations.containsKey(box) &&
+                annotatedImages.any { annotated -> box.isLikelyDuplicateOf(annotated) }
+        }
+    }
+
+    private fun ScaledBox.isImagePlaceholder(): Boolean {
+        return label.startsWith("image_placeholder")
+    }
+
+    private fun ScaledBox.isLikelyDuplicateOf(annotated: ScaledBox): Boolean {
+        val maxDuplicateArea = annotated.area * 0.35
+        val verticalGap = when {
+            y >= annotated.y + annotated.h -> y - (annotated.y + annotated.h)
+            annotated.y >= y + h -> annotated.y - (y + h)
+            else -> 0
+        }
+        val hasHorizontalOverlap = x < annotated.x + annotated.w && x + w > annotated.x
+        return area < maxDuplicateArea &&
+            hasHorizontalOverlap &&
+            verticalGap <= annotated.h / 2
+    }
+
+    private val ScaledBox.area: Int
+        get() = w * h
+
+    private fun DetectionResult.isInvalidWidgetTag(): Boolean {
+        return label == "widget_tag" && WidgetTagParser.extractTag(text) == null
+    }
+
+    private fun DetectionResult.isCanvasRenderable(): Boolean {
+        return when (region) {
+            null, SketchRegion.CANVAS -> true
+            SketchRegion.CROSS_BOUNDARY -> label == "text" &&
+                text.isNotBlank() &&
+                !MetadataDetector.isCanvasMetadata(text) &&
+                !WidgetTagParser.isTagSequence(text)
+            SketchRegion.LEFT_METADATA, SketchRegion.RIGHT_METADATA -> false
         }
     }
 

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/model/DetectionResult.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/model/DetectionResult.kt
@@ -7,5 +7,6 @@ data class DetectionResult(
     val label: String,
     val score: Float,
     var text: String = "",
-    val isYolo: Boolean = true
+    val isYolo: Boolean = true,
+    val region: SketchRegion? = null
 )

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/model/SketchRegion.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/model/SketchRegion.kt
@@ -1,0 +1,8 @@
+package org.appdevforall.codeonthego.computervision.domain.model
+
+enum class SketchRegion {
+    LEFT_METADATA,
+    CANVAS,
+    RIGHT_METADATA,
+    CROSS_BOUNDARY
+}

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/AttributeModels.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/AttributeModels.kt
@@ -77,7 +77,7 @@ enum class AttributeKey(
     val aliases: List<String>,
     val valueType: ValueType = ValueType.RAW
 ) {
-    WIDTH("android:layout_width", listOf("layout_width", "width"), ValueType.DIMENSION),
+    WIDTH("android:layout_width", listOf("layout_width", "width", "layout_idth", "layaut_width"), ValueType.DIMENSION),
     HEIGHT("android:layout_height", listOf("layout_height", "height"), ValueType.DIMENSION),
     ID("android:id", listOf("id"), ValueType.ID),
     TEXT("android:text", listOf("text"), ValueType.TEXT_CONTENT),
@@ -145,7 +145,7 @@ enum class AttributeKey(
     LAYOUT_MARGIN_RIGHT("android:layout_marginRight", listOf("layout_marginright", "layout_margin_right", "margin_right"), ValueType.DIMENSION),
 
     LAYOUT_WEIGHT("android:layout_weight", listOf("layout_weight", "weight"), ValueType.FLOAT),
-    LAYOUT_GRAVITY("android:layout_gravity", listOf("layout_gravity", "layaut_gravity")),
+    LAYOUT_GRAVITY("android:layout_gravity", listOf("layout_gravity", "layoutgravity", "layout_graity", "layoutgraity", "layaut_gravity", "layautgravity", "layaut_graity")),
     GRAVITY("android:gravity", listOf("gravity")),
     ORIENTATION("android:orientation", listOf("orientation")),
 

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/FuzzyAttributeParser.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/FuzzyAttributeParser.kt
@@ -15,6 +15,16 @@ object FuzzyAttributeParser {
     )
     private val inputTypeValues = InputTypeValueSet.values.map { it.lowercase() }.toSet()
     private val sanitizer = OcrSanitizerFactory.createDefaultSanitizer()
+    private const val SWITCH_TAG = "Switch"
+    private const val IMAGE_VIEW_TAG = "ImageView"
+    private const val SWITCH_ID_TARGET = "switch"
+    private const val IMAGE_VIEW_ID_PREFIX = "im"
+    private const val IMAGE_VIEW_ID_VIEW_TOKEN = "view"
+    private const val SWITCH_ID_OCR_THRESHOLD = 70
+    private const val IMAGE_VIEW_ID_OCR_THRESHOLD = 80
+    private val switchIdTargets = listOf(SWITCH_ID_TARGET)
+    private val imageViewIdPrefixTargets = listOf(IMAGE_VIEW_ID_PREFIX, "img", "image")
+    private val imageViewIdViewTargets = listOf(IMAGE_VIEW_ID_VIEW_TOKEN)
 
     private val cleaners = mapOf(
         ValueType.TEXT_CONTENT to TextContentCleaner,
@@ -42,7 +52,11 @@ object FuzzyAttributeParser {
         val normalizedInput = normalizeOcrKeyPhrases(annotation.replace(Regex("\\s+:"), ":"))
         val tokens = tokenizeAnnotation(normalizedInput)
 
-        val rawAttributes = mapTokensToAttributes(tokens, tag)
+        val rawAttributes = recoverMissingAttributes(
+            mapTokensToAttributes(tokens, tag),
+            normalizedInput,
+            tag
+        )
         val finalAttributes = grammarValidator.enforceGrammar(rawAttributes, tag)
 
         return finalAttributes
@@ -62,6 +76,8 @@ object FuzzyAttributeParser {
 
     private fun normalizeOcrKeyPhrases(annotation: String): String {
         return textColorKeyPhraseRegex.replace(annotation, "textcolor")
+            .replace(Regex("\\blay(?:out|aut)[_\\- ]?gr(?:av|a)ity\\b", RegexOption.IGNORE_CASE), "layout_gravity")
+            .replace(Regex("\\blayoutgravity\\b", RegexOption.IGNORE_CASE), "layout_gravity")
     }
 
     private fun tokenizeDelimitedChunk(chunk: String): List<String> {
@@ -113,6 +129,7 @@ object FuzzyAttributeParser {
 
         return when {
             currentKey == AttributeKey.INPUT_TYPE && lowerToken in inputTypeValues -> true
+            currentKey in setOf(AttributeKey.LAYOUT_GRAVITY, AttributeKey.GRAVITY) && lowerToken in GravityValueSet.values -> true
             currentKey?.valueType == ValueType.COLOR && isColorToken(lowerToken) -> true
             currentKey?.valueType == ValueType.DIMENSION && DimensionValueSet.allKeywords.any { it in lowerToken } -> true
             currentKey?.valueType in numericTypes -> lowerToken.any { it.isDigit() }
@@ -127,12 +144,19 @@ object FuzzyAttributeParser {
     private fun flushAttribute(key: AttributeKey?, rawValue: String, tag: String, destination: MutableMap<String, String>) {
         if (key == null || rawValue.isBlank()) return
 
+        val trimmedRawValue = rawValue.trim()
         val cleaner = cleaners[key.valueType] ?: ValueCleaner { it }
-        val cleanedValue = cleaner.clean(rawValue.trim())
+        val cleanedValue = when (key) {
+            AttributeKey.ID -> normalizeIdValue(trimmedRawValue, tag)
+            AttributeKey.LAYOUT_GRAVITY, AttributeKey.GRAVITY -> cleanGravityValue(trimmedRawValue)
+            else -> cleaner.clean(trimmedRawValue)
+        }
 
         if (cleanedValue.isNotEmpty()) {
-            val (xmlAttr, finalValue) = resolveXmlAttribute(key, cleanedValue, tag)
-            if (!destination.containsKey(xmlAttr)) {
+            val recoveredValue = recoverValue(key, rawValue, cleanedValue, tag)
+            val (xmlAttr, finalValue) = resolveXmlAttribute(key, recoveredValue, tag)
+            val existingValue = destination[xmlAttr]
+            if (existingValue == null || shouldReplaceAttribute(xmlAttr, existingValue, finalValue, tag)) {
                 destination[xmlAttr] = finalValue
             }
         }
@@ -168,4 +192,99 @@ object FuzzyAttributeParser {
         if (key == AttributeKey.ID) return key.xmlName to value.replace(" ", "_")
         return key.xmlName to value
     }
+
+    private fun shouldReplaceAttribute(xmlAttr: String, existingValue: String, candidateValue: String, tag: String): Boolean {
+        val existingValid = grammarValidator.enforceGrammar(mapOf(xmlAttr to existingValue), tag).containsKey(xmlAttr)
+        val candidateValid = grammarValidator.enforceGrammar(mapOf(xmlAttr to candidateValue), tag).containsKey(xmlAttr)
+        return !existingValid && candidateValid
+    }
+
+    private fun recoverValue(key: AttributeKey, rawValue: String, cleanedValue: String, tag: String): String {
+        val switchWidthLostLeadingOne = tag == SWITCH_TAG &&
+            key == AttributeKey.WIDTH &&
+            cleanedValue == "0dp" &&
+            Regex("^0{2}\\s*dp$", RegexOption.IGNORE_CASE).matches(rawValue.trim())
+
+        return if (switchWidthLostLeadingOne) "100dp" else cleanedValue
+    }
+
+    private fun recoverMissingAttributes(attributes: Map<String, String>, annotation: String, tag: String): Map<String, String> {
+        if (tag != IMAGE_VIEW_TAG || attributes.containsKey(AttributeKey.ID.xmlName)) return attributes
+
+        val recoveredId = imageViewIdRegex.find(annotation)?.value
+            ?: imageViewIdCompactRegex.find(annotation)?.value
+            ?: return attributes
+
+        return attributes + (AttributeKey.ID.xmlName to normalizeIdValue(recoveredId, tag))
+    }
+
+    private fun normalizeIdValue(rawValue: String, tag: String): String {
+        val cleaned = IdCleaner.clean(rawValue)
+        val tokens = cleaned.split('_').filter { it.isNotBlank() }
+
+        return normalizeSwitchIdIfNeeded(tokens, tag)
+            ?: normalizeImageViewIdIfNeeded(tokens, tag)
+            ?: cleaned
+    }
+
+    private fun normalizeSwitchIdIfNeeded(tokens: List<String>, tag: String): String? {
+        if (tag != SWITCH_TAG || !isSwitchIdOcrCandidate(tokens)) return null
+        return buildId(SWITCH_ID_TARGET, extractTrailingNumber(tokens))
+    }
+
+    private fun isSwitchIdOcrCandidate(tokens: List<String>): Boolean {
+        val firstToken = tokens.firstOrNull() ?: return false
+        return fuzzyTokenScore(firstToken, switchIdTargets) >= SWITCH_ID_OCR_THRESHOLD
+    }
+
+    private fun normalizeImageViewIdIfNeeded(tokens: List<String>, tag: String): String? {
+        if (tag != IMAGE_VIEW_TAG || !isImageViewIdOcrCandidate(tokens)) return null
+        return buildId(IMAGE_VIEW_ID_PREFIX, IMAGE_VIEW_ID_VIEW_TOKEN, extractTrailingNumber(tokens))
+    }
+
+    private fun isImageViewIdOcrCandidate(tokens: List<String>): Boolean {
+        if (tokens.isEmpty()) return false
+        val hasImagePrefix = tokens.any(::isImageViewPrefixToken)
+        val hasViewToken = tokens.any(::isImageViewViewToken)
+        return hasImagePrefix && hasViewToken
+    }
+
+    private fun isImageViewPrefixToken(token: String): Boolean {
+        return token == "m" ||
+            token in imageViewIdPrefixTargets ||
+            fuzzyTokenScore(token, imageViewIdPrefixTargets) >= IMAGE_VIEW_ID_OCR_THRESHOLD
+    }
+
+    private fun isImageViewViewToken(token: String): Boolean {
+        return token in imageViewIdViewTargets ||
+            fuzzyTokenScore(token, imageViewIdViewTargets) >= IMAGE_VIEW_ID_OCR_THRESHOLD
+    }
+
+    private fun extractTrailingNumber(tokens: List<String>): String? {
+        return tokens.lastOrNull()?.takeIf { token -> token.all(Char::isDigit) }
+    }
+
+    private fun buildId(vararg parts: String?): String {
+        return parts.filterNotNull().joinToString("_")
+    }
+
+    private fun fuzzyTokenScore(token: String, targets: List<String>): Int {
+        return FuzzySearch.extractOne(token, targets).score
+    }
+
+    private fun cleanGravityValue(rawValue: String): String {
+        val normalized = rawValue.lowercase().replace(Regex("[^a-z_]+"), " ")
+        return GravityValueSet.values.firstOrNull { value ->
+            Regex("(^|\\s)${Regex.escape(value)}(\\s|$)").containsMatchIn(normalized)
+        } ?: rawValue.trim()
+    }
+
+    private val imageViewIdRegex = Regex(
+        "\\b(?:i?m)[_\\s-]+view[_\\s-]+\\d+\\b",
+        RegexOption.IGNORE_CASE
+    )
+    private val imageViewIdCompactRegex = Regex(
+        "\\b(?:i?m)view\\d+\\b",
+        RegexOption.IGNORE_CASE
+    )
 }

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/ValueCleanersImpl.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/ValueCleanersImpl.kt
@@ -59,7 +59,7 @@ internal object DimensionCleaner : ValueCleaner {
 
         val numMatch = leadingNumberRegex.find(numericPart)?.value
             ?: return trimmedValue
-        val correctedNum = removeOcrTrailingZero(numMatch)
+        val correctedNum = removeOcrTrailingZero(numMatch).trimLeadingZeros()
 
         return "$correctedNum$originalUnit"
     }
@@ -67,6 +67,13 @@ internal object DimensionCleaner : ValueCleaner {
     private fun removeOcrTrailingZero(num: String): String {
         val isOcrArtifact = num.endsWith("0") && (num.toLongOrNull() ?: 0L) >= 1000L
         return if (isOcrArtifact) num.dropLast(1) else num
+    }
+
+    private fun String.trimLeadingZeros(): String {
+        val negative = startsWith("-")
+        val digits = if (negative) drop(1) else this
+        val trimmed = digits.trimStart('0').ifEmpty { "0" }
+        return if (negative) "-$trimmed" else trimmed
     }
 }
 
@@ -106,13 +113,11 @@ internal object ColorCleaner : ValueCleaner {
 }
 
 internal object IdCleaner : ValueCleaner {
-    private val ID_VOCABULARY = listOf("cb", "rb", "group", "checkbox", "radio", "btn", "button", "text", "view", "img", "image", "input")
+    private val ID_VOCABULARY = listOf("cb", "rb", "group", "checkbox", "radio", "btn", "button", "text", "view", "img", "image", "input", "switch")
     private val nonAlphanumericRegex = Regex("[^a-z0-9_]")
 
     override fun clean(rawValue: String): String {
-        val firstWord = rawValue.trim().split(Regex("\\s+")).firstOrNull() ?: rawValue
-
-        val cleaned = firstWord.lowercase()
+        val cleaned = rawValue.trim().lowercase()
             .replace(Regex("inm|rn|wm|nm")) { m -> if (m.value == "inm") "im" else "m" }
             .replace(nonAlphanumericRegex, "_")
             .replace(Regex("_+"), "_")

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/usecase/RunVisionUC.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/usecase/RunVisionUC.kt
@@ -7,7 +7,9 @@ import org.appdevforall.codeonthego.computervision.domain.DetectionMerger
 import org.appdevforall.codeonthego.computervision.domain.GenericBoxResolver
 import org.appdevforall.codeonthego.computervision.domain.MarginAnnotationParser
 import org.appdevforall.codeonthego.computervision.domain.RegionOcrProcessor
+import org.appdevforall.codeonthego.computervision.domain.SketchRegionClassifier
 import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
+import org.appdevforall.codeonthego.computervision.domain.model.SketchRegion
 import org.appdevforall.codeonthego.computervision.ui.CvOperation
 
 /**
@@ -32,7 +34,13 @@ class RunVisionUC(
     ): Result<VisionResult> = runCatching {
 
         onProgress(CvOperation.RunningYolo)
-        val rawDetections = repository.detectWidgets(bitmap).getOrThrow()
+        val leftBoundPx = bitmap.width * leftPct
+        val rightBoundPx = bitmap.width * rightPct
+        val rawDetections = SketchRegionClassifier.classifyDetections(
+            detections = repository.detectWidgets(bitmap).getOrThrow(),
+            leftBoundPx = leftBoundPx,
+            rightBoundPx = rightBoundPx
+        )
         val resolvedDetections = boxResolver.resolve(rawDetections)
 
         onProgress(CvOperation.RunningOcr)
@@ -42,16 +50,20 @@ class RunVisionUC(
         val mergedDetections = DetectionMerger(
             ocrResult.enrichedDetections,
             ocrResult.remainingDetections,
-            ocrResult.fullImageTextBlocks
+            ocrResult.fullImageTextBlocks,
+            leftBoundPx,
+            rightBoundPx
         ).merge()
 
-        val leftBound = bitmap.width * leftPct
-        val rightBound = bitmap.width * rightPct
         val canvasOnlyMerged = mergedDetections.filter { detection ->
-            detection.isYolo || detection.boundingBox.centerX() in leftBound..rightBound
+            detection.region == null || detection.region == SketchRegion.CANVAS
+        }
+        val fullImageMarginDetections = mergedDetections.filter { detection ->
+            !detection.isYolo &&
+                (detection.region == SketchRegion.LEFT_METADATA || detection.region == SketchRegion.RIGHT_METADATA)
         }
 
-        val allDetections = canvasOnlyMerged + ocrResult.marginDetections
+        val allDetections = canvasOnlyMerged + ocrResult.marginDetections + fullImageMarginDetections
 
         val (canvasDetections, annotationMap) = MarginAnnotationParser.parse(
             detections = allDetections,

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/AndroidConstants.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/AndroidConstants.kt
@@ -23,6 +23,7 @@ object AndroidWidgetTags {
     const val CHECK_BOX = "CheckBox"
     const val RADIO_BUTTON = "RadioButton"
     const val SWITCH = "Switch"
+    const val SWITCH_COMPAT = "androidx.appcompat.widget.SwitchCompat"
     const val EDIT_TEXT = "EditText"
     const val SPINNER = "Spinner"
     const val SEEK_BAR = "SeekBar"

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/AndroidWidget.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/AndroidWidget.kt
@@ -2,6 +2,7 @@ package org.appdevforall.codeonthego.computervision.domain.xml
 
 import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
 import org.appdevforall.codeonthego.computervision.domain.parser.AttributeKey
+import org.appdevforall.codeonthego.computervision.domain.WidgetTagParser
 import org.appdevforall.codeonthego.computervision.utils.extractOcrEntries
 
 sealed class AndroidWidget(
@@ -259,12 +260,14 @@ class CheckBoxWidget(
 class SwitchWidget(
     override val box: ScaledBox, parsedAttrs: Map<String, String>
 ) : AndroidWidget(box, parsedAttrs) {
-    override val tag = AndroidWidgetTags.SWITCH
+    override val tag = AndroidWidgetTags.SWITCH_COMPAT
     override fun fallbackIdLabel(): String = "switch"
 
     override fun specificAttributes(): Map<String, String> {
         val attrs = mutableMapOf<String, String>()
-        val switchText = parsedAttrs[AttributeKey.TEXT.xmlName] ?: box.text.trim().takeIf { it.isNotEmpty() && it != box.label } ?: AndroidWidgetTags.SWITCH
+        val switchText = parsedAttrs[AttributeKey.TEXT.xmlName]
+            ?: box.text.trim().takeIf { it.isVisibleSwitchLabel(box.label) }
+            ?: ""
 
         attrs[AttributeKey.TEXT.xmlName] = switchText
         attrs["tools:ignore"] = "HardcodedText"
@@ -273,6 +276,10 @@ class SwitchWidget(
             attrs[AttributeKey.CHECKED.xmlName] = parsedAttrs[AttributeKey.CHECKED.xmlName] ?: AndroidConstants.TRUE
         }
         return attrs
+    }
+
+    private fun String.isVisibleSwitchLabel(label: String): Boolean {
+        return isNotEmpty() && this != label && !WidgetTagParser.isTagSequence(this)
     }
 }
 

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/utils/DetectionVisualizer.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/utils/DetectionVisualizer.kt
@@ -10,6 +10,7 @@ import android.graphics.drawable.Drawable
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.graphics.toColorInt
 import com.appdevforall.sketchtoui.plugin.R
+import org.appdevforall.codeonthego.computervision.domain.WidgetTagParser
 import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
 
 
@@ -115,6 +116,9 @@ class DetectionVisualizer(private val context: Context) {
         val placeholderIdsByDetection = mapPlaceholderDetections(detections)
 
         for (result in detections) {
+            if (result.isInvalidWidgetTag()) {
+                continue
+            }
             if (result.label == IMAGE_PLACEHOLDER_LABEL) {
                 val placeholderId = placeholderIdsByDetection[result] ?: continue
                 val hasSelectedImage = selectedPlaceholderIds.contains(placeholderId)
@@ -223,5 +227,9 @@ class DetectionVisualizer(private val context: Context) {
 
     fun clearCache() {
         deleteIconClickableAreas.clear()
+    }
+
+    private fun DetectionResult.isInvalidWidgetTag(): Boolean {
+        return label == "widget_tag" && WidgetTagParser.extractTag(text) == null
     }
 }

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParserTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParserTest.kt
@@ -273,6 +273,32 @@ class FuzzyAttributeParserTest {
     }
 
     @Test
+    fun `switch id OCR and dropped leading width digit are recovered`() {
+        val result = FuzzyAttributeParser.parse(
+            "layout_width: layaut_width: 00dp id: Switeh 1 id: Switeh 1 checked:felse checked:false",
+            "Switch"
+        )
+
+        assertEquals("switch_1", result["android:id"])
+        assertEquals("100dp", result["android:layout_width"])
+        assertEquals("false", result["android:checked"])
+    }
+
+    @Test
+    fun `image view metadata recovers id layout gravity and drawable`() {
+        val result = FuzzyAttributeParser.parse(
+            "layout-idth: 200oP | layout.height: wrap content | src: images | layaut-graity: start w/ap iol: m_View 1",
+            "ImageView"
+        )
+
+        assertEquals("im_view_1", result["android:id"])
+        assertEquals("200dp", result["android:layout_width"])
+        assertEquals("wrap_content", result["android:layout_height"])
+        assertEquals("start", result["android:layout_gravity"])
+        assertEquals("@drawable/images", result["android:src"])
+    }
+
+    @Test
     fun `hex color values pass through unchanged`() {
         val annotation = "background: #FF5733 | width: 100dp"
         val result = FuzzyAttributeParser.parse(annotation, "TextView")

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/YoloToXmlConverterTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/YoloToXmlConverterTest.kt
@@ -1,0 +1,292 @@
+package org.appdevforall.codeonthego.computervision.domain
+
+import android.graphics.RectF
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
+import org.appdevforall.codeonthego.computervision.domain.model.SketchRegion
+import org.appdevforall.codeonthego.computervision.domain.parser.FuzzyAttributeParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class YoloToXmlConverterTest {
+
+    @Test
+    fun `screenshot metadata is matched to switch and image by canvas tags`() {
+        val detections = listOf(
+            detection("switch_off", "", 250f, 100f, 330f, 140f, region = SketchRegion.CANVAS),
+            detection("image_placeholder", "", 260f, 260f, 460f, 360f, region = SketchRegion.CANVAS),
+            detection("image_placeholder", "", 300f, 390f, 330f, 420f, region = SketchRegion.CANVAS),
+            detection("text", "SW-1", 220f, 100f, 250f, 125f, isYolo = false, region = SketchRegion.CANVAS),
+            detection("text", "P-1", 220f, 260f, 250f, 285f, isYolo = false, region = SketchRegion.CANVAS),
+            detection("text", "P-1 P-1", 480f, 260f, 560f, 285f, isYolo = false, region = SketchRegion.CROSS_BOUNDARY),
+            detection(
+                "text",
+                "SW-1 layout_width: layaut_width: 00dp id: Switeh 1 id: Switeh 1 checked:felse checked:false",
+                20f,
+                100f,
+                190f,
+                145f,
+                isYolo = false,
+                region = SketchRegion.LEFT_METADATA
+            ),
+            detection("text", "P-1 P-1", 700f, 255f, 760f, 280f, isYolo = false, region = SketchRegion.RIGHT_METADATA),
+            detection("text", "layaut-graity: start w/ap iol: m_View 1", 700f, 285f, 930f, 310f, isYolo = false, region = SketchRegion.RIGHT_METADATA),
+            detection("text", "P-1 src: images", 700f, 315f, 830f, 340f, isYolo = false, region = SketchRegion.RIGHT_METADATA)
+        )
+
+        val (canvasDetections, annotationMap) = MarginAnnotationParser.parse(
+            detections = detections,
+            imageWidth = 1000,
+            leftGuidePct = 0.20f,
+            rightGuidePct = 0.60f
+        )
+
+        val (xml, _) = YoloToXmlConverter.generateXmlLayout(
+            detections = canvasDetections,
+            annotations = annotationMap,
+            sourceImageWidth = 1000,
+            sourceImageHeight = 1000,
+            targetDpWidth = 1000,
+            targetDpHeight = 1000,
+            wrapInScroll = false
+        )
+
+        assertTrue(xml.contains("""<androidx.appcompat.widget.SwitchCompat"""))
+        assertTrue(xml.contains("""android:id="@+id/switch_1""""))
+        assertTrue(xml.contains("""android:layout_width="100dp""""))
+        assertTrue(xml.contains("""android:checked="false""""))
+        assertFalse(xml.contains("""android:text="P-1 P-1""""))
+        assertTrue(xml.contains("""android:id="@+id/im_view_1""""))
+        assertTrue(xml.contains("""android:layout_gravity="start""""))
+        assertTrue(xml.contains("""android:src="@drawable/images""""))
+        assertFalse(xml.contains("""android:id="@+id/image_placeholder_0""""))
+    }
+
+    @Test
+    fun `right margin image annotation preserves id gravity and src`() {
+        val detections = listOf(
+            detection("image_placeholder", "", 260f, 260f, 460f, 360f, region = SketchRegion.CANVAS),
+            detection("text", "P-1", 220f, 260f, 250f, 285f, isYolo = false, region = SketchRegion.CANVAS),
+            detection("text", "P-1", 700f, 255f, 760f, 280f, isYolo = false, region = SketchRegion.RIGHT_METADATA),
+            detection("text", "layout-width: 200dp", 700f, 285f, 860f, 310f, isYolo = false, region = SketchRegion.RIGHT_METADATA),
+            detection("text", "layout-height: wrap_content", 700f, 315f, 900f, 340f, isYolo = false, region = SketchRegion.RIGHT_METADATA),
+            detection("text", "id: im_view_1", 700f, 345f, 840f, 370f, isYolo = false, region = SketchRegion.RIGHT_METADATA),
+            detection("text", "src: images", 700f, 375f, 820f, 400f, isYolo = false, region = SketchRegion.RIGHT_METADATA),
+            detection("text", "layout-gravity: start", 700f, 405f, 900f, 430f, isYolo = false, region = SketchRegion.RIGHT_METADATA)
+        )
+
+        val (canvasDetections, annotationMap) = MarginAnnotationParser.parse(
+            detections = detections,
+            imageWidth = 1000,
+            leftGuidePct = 0.20f,
+            rightGuidePct = 0.60f
+        )
+        val parsed = FuzzyAttributeParser.parse(annotationMap["P-1"], "ImageView")
+        val (xml, _) = YoloToXmlConverter.generateXmlLayout(
+            detections = canvasDetections,
+            annotations = annotationMap,
+            sourceImageWidth = 1000,
+            sourceImageHeight = 1000,
+            targetDpWidth = 1000,
+            targetDpHeight = 1000,
+            wrapInScroll = false
+        )
+
+        assertEquals("im_view_1", parsed["android:id"])
+        assertEquals("start", parsed["android:layout_gravity"])
+        assertEquals("@drawable/images", parsed["android:src"])
+        assertTrue(xml.contains("""android:id="@+id/im_view_1""""))
+        assertFalse(xml.contains("""android:id="@+id/image_placeholder_0""""))
+    }
+
+    @Test
+    fun `blank widget tag detections are ignored by parser and do not alter xml`() {
+        val blankWidgetTag = detection(
+            "widget_tag",
+            "",
+            564.047f,
+            1342.8032f,
+            616.454f,
+            1382.0607f,
+            region = SketchRegion.CANVAS
+        ).copy(score = 0.35572785f)
+        val baseDetections = listOf(
+            detection("image_placeholder", "", 260f, 260f, 460f, 360f, region = SketchRegion.CANVAS),
+            detection("text", "P-1", 220f, 260f, 250f, 285f, isYolo = false, region = SketchRegion.CANVAS),
+            detection("text", "P-1", 700f, 255f, 760f, 280f, isYolo = false, region = SketchRegion.RIGHT_METADATA),
+            detection("text", "id: im_view_1", 700f, 345f, 840f, 370f, isYolo = false, region = SketchRegion.RIGHT_METADATA),
+            detection("text", "src: images", 700f, 375f, 820f, 400f, isYolo = false, region = SketchRegion.RIGHT_METADATA)
+        )
+
+        val (canvasWithoutBlank, annotationsWithoutBlank) = MarginAnnotationParser.parse(
+            detections = baseDetections,
+            imageWidth = 1000,
+            leftGuidePct = 0.20f,
+            rightGuidePct = 0.60f
+        )
+        val (canvasWithBlank, annotationsWithBlank) = MarginAnnotationParser.parse(
+            detections = baseDetections + blankWidgetTag,
+            imageWidth = 1000,
+            leftGuidePct = 0.20f,
+            rightGuidePct = 0.60f
+        )
+        val (xmlWithoutBlank, _) = YoloToXmlConverter.generateXmlLayout(
+            detections = canvasWithoutBlank,
+            annotations = annotationsWithoutBlank,
+            sourceImageWidth = 1000,
+            sourceImageHeight = 1500,
+            targetDpWidth = 1000,
+            targetDpHeight = 1500,
+            wrapInScroll = false
+        )
+        val (xmlWithBlank, _) = YoloToXmlConverter.generateXmlLayout(
+            detections = canvasWithBlank,
+            annotations = annotationsWithBlank,
+            sourceImageWidth = 1000,
+            sourceImageHeight = 1500,
+            targetDpWidth = 1000,
+            targetDpHeight = 1500,
+            wrapInScroll = false
+        )
+
+        assertFalse(canvasWithBlank.any { it.label == "widget_tag" && it.text.isBlank() })
+        assertEquals(annotationsWithoutBlank, annotationsWithBlank)
+        assertEquals(xmlWithoutBlank, xmlWithBlank)
+        assertTrue(xmlWithBlank.contains("""android:id="@+id/im_view_1""""))
+    }
+
+    @Test
+    fun `metadata region text is not treated as real widget text`() {
+        val detections = listOf(
+            detection("text", "P-1 layout_width: 200dp", 700f, 260f, 900f, 290f, isYolo = false, region = SketchRegion.RIGHT_METADATA),
+            detection("switch_off", "WiFi", 250f, 100f, 330f, 140f, region = SketchRegion.CANVAS)
+        )
+
+        val (xml, _) = YoloToXmlConverter.generateXmlLayout(
+            detections = detections,
+            annotations = emptyMap(),
+            sourceImageWidth = 1000,
+            sourceImageHeight = 1000,
+            targetDpWidth = 1000,
+            targetDpHeight = 1000,
+            wrapInScroll = false
+        )
+
+        assertTrue(xml.contains("""android:text="WiFi""""))
+        assertFalse(xml.contains("layout_width: 200dp"))
+    }
+
+    @Test
+    fun `cross boundary visible text remains renderable`() {
+        val detections = listOf(
+            detection("text", "Edge label", 190f, 260f, 230f, 285f, isYolo = false, region = SketchRegion.CROSS_BOUNDARY)
+        )
+
+        val (canvasDetections, annotationMap) = MarginAnnotationParser.parse(
+            detections = detections,
+            imageWidth = 1000,
+            leftGuidePct = 0.20f,
+            rightGuidePct = 0.60f
+        )
+
+        val (xml, _) = YoloToXmlConverter.generateXmlLayout(
+            detections = canvasDetections,
+            annotations = annotationMap,
+            sourceImageWidth = 1000,
+            sourceImageHeight = 1000,
+            targetDpWidth = 1000,
+            targetDpHeight = 1000,
+            wrapInScroll = false
+        )
+
+        assertTrue(xml.contains("""android:text="Edge label""""))
+    }
+
+    @Test
+    fun `small unmatched icons remain renderable widgets`() {
+        val detections = listOf(
+            detection("image_placeholder", "", 260f, 260f, 460f, 360f, region = SketchRegion.CANVAS),
+            detection("icon", "", 300f, 390f, 330f, 420f, region = SketchRegion.CANVAS),
+            detection("text", "P-1", 220f, 260f, 250f, 285f, isYolo = false, region = SketchRegion.CANVAS),
+            detection("text", "P-1", 700f, 255f, 760f, 280f, isYolo = false, region = SketchRegion.RIGHT_METADATA),
+            detection("text", "id: im_view_1", 700f, 345f, 840f, 370f, isYolo = false, region = SketchRegion.RIGHT_METADATA)
+        )
+
+        val (canvasDetections, annotationMap) = MarginAnnotationParser.parse(
+            detections = detections,
+            imageWidth = 1000,
+            leftGuidePct = 0.20f,
+            rightGuidePct = 0.60f
+        )
+
+        val (xml, _) = YoloToXmlConverter.generateXmlLayout(
+            detections = canvasDetections,
+            annotations = annotationMap,
+            sourceImageWidth = 1000,
+            sourceImageHeight = 1000,
+            targetDpWidth = 1000,
+            targetDpHeight = 1000,
+            wrapInScroll = false
+        )
+
+        assertTrue(xml.contains("""android:id="@+id/im_view_1""""))
+        assertTrue(xml.contains("""android:id="@+id/icon_0""""))
+    }
+
+    @Test
+    fun `small unmatched image placeholders away from annotated images remain renderable widgets`() {
+        val detections = listOf(
+            detection("image_placeholder", "", 260f, 260f, 460f, 360f, region = SketchRegion.CANVAS),
+            detection("image_placeholder", "", 760f, 390f, 790f, 420f, region = SketchRegion.CANVAS),
+            detection("text", "P-1", 220f, 260f, 250f, 285f, isYolo = false, region = SketchRegion.CANVAS),
+            detection("text", "P-1", 700f, 255f, 760f, 280f, isYolo = false, region = SketchRegion.RIGHT_METADATA),
+            detection("text", "id: im_view_1", 700f, 345f, 840f, 370f, isYolo = false, region = SketchRegion.RIGHT_METADATA)
+        )
+
+        val (canvasDetections, annotationMap) = MarginAnnotationParser.parse(
+            detections = detections,
+            imageWidth = 1000,
+            leftGuidePct = 0.20f,
+            rightGuidePct = 0.60f
+        )
+
+        val (xml, _) = YoloToXmlConverter.generateXmlLayout(
+            detections = canvasDetections,
+            annotations = annotationMap,
+            sourceImageWidth = 1000,
+            sourceImageHeight = 1000,
+            targetDpWidth = 1000,
+            targetDpHeight = 1000,
+            wrapInScroll = false
+        )
+
+        assertTrue(xml.contains("""android:id="@+id/im_view_1""""))
+        assertTrue(xml.contains("""android:id="@+id/image_placeholder_0""""))
+    }
+
+    private fun detection(
+        label: String,
+        text: String,
+        left: Float,
+        top: Float,
+        right: Float,
+        bottom: Float,
+        isYolo: Boolean = true,
+        region: SketchRegion? = null
+    ): DetectionResult {
+        return DetectionResult(
+            boundingBox = RectF(left, top, right, bottom).apply {
+                this.left = left
+                this.top = top
+                this.right = right
+                this.bottom = bottom
+            },
+            label = label,
+            score = 0.99f,
+            text = text,
+            isYolo = isYolo,
+            region = region
+        )
+    }
+}

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/xml/LayoutRendererTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/xml/LayoutRendererTest.kt
@@ -104,6 +104,74 @@ class LayoutRendererTest {
         assertTrue(!xml.contains("""android:id="@+id/rb_group_1_text_site_16sp""""))
     }
 
+    @Test
+    fun `switch and image metadata render recovered xml without tag text`() {
+        val switch = box("switch_off", "P-1 P-1", x = 0, y = 0, w = 80, h = 40)
+        val image = box("image_placeholder", "", x = 0, y = 60, w = 200, h = 100)
+        val context = XmlContext()
+
+        val renderer = LayoutRenderer(
+            context = context,
+            annotations = identityAnnotationMap(
+                switch to "layout_width: layaut_width: 00dp id: Switeh 1 id: Switeh 1 checked:felse checked:false",
+                image to "layout-idth: 200oP | layout.height: wrap content | src: images | layaut-graity: start w/ap iol: m_View 1"
+            )
+        )
+
+        renderer.render(LayoutItem.SimpleView(switch))
+        renderer.render(LayoutItem.SimpleView(image))
+
+        val xml = context.toString()
+
+        assertTrue(xml.contains("""<androidx.appcompat.widget.SwitchCompat"""))
+        assertTrue(xml.contains("""android:id="@+id/switch_1""""))
+        assertTrue(xml.contains("""android:layout_width="100dp""""))
+        assertTrue(xml.contains("""android:checked="false""""))
+        assertTrue(xml.contains("""android:text=""""))
+        assertFalse(xml.contains("""android:text="P-1 P-1""""))
+        assertTrue(xml.contains("""<ImageView"""))
+        assertTrue(xml.contains("""android:id="@+id/im_view_1""""))
+        assertTrue(xml.contains("""android:layout_gravity="start""""))
+        assertTrue(xml.contains("""android:src="@drawable/images""""))
+    }
+
+    @Test
+    fun `real switch labels remain visible`() {
+        val switch = box("switch_off", "WiFi", x = 0, y = 0, w = 80, h = 40)
+        val context = XmlContext()
+
+        val renderer = LayoutRenderer(
+            context = context,
+            annotations = emptyMap()
+        )
+
+        renderer.render(LayoutItem.SimpleView(switch))
+
+        val xml = context.toString()
+
+        assertTrue(xml.contains("""<androidx.appcompat.widget.SwitchCompat"""))
+        assertTrue(xml.contains("""android:text="WiFi""""))
+    }
+
+    @Test
+    fun `image without recoverable metadata keeps fallback id`() {
+        val image = box("image_placeholder", "", x = 0, y = 0, w = 200, h = 100)
+        val context = XmlContext()
+
+        val renderer = LayoutRenderer(
+            context = context,
+            annotations = emptyMap()
+        )
+
+        renderer.render(LayoutItem.SimpleView(image))
+
+        val xml = context.toString()
+
+        assertTrue(xml.contains("""<ImageView"""))
+        assertTrue(xml.contains("""android:id="@+id/image_placeholder_0""""))
+        assertFalse(xml.contains("""android:id="@+id/im_view_1""""))
+    }
+
     private fun checkboxBox(y: Int, text: String, checked: Boolean = false): ScaledBox {
         val label = if (checked) "checkbox_checked" else "checkbox_unchecked"
         return ScaledBox(
@@ -132,5 +200,51 @@ class LayoutRendererTest {
             centerY = y + 10,
             rect = Rect(0, y, 20, y + 20)
         )
+    }
+
+    private fun box(label: String, text: String, x: Int, y: Int, w: Int, h: Int): ScaledBox {
+        return ScaledBox(
+            label = label,
+            text = text,
+            x = x,
+            y = y,
+            w = w,
+            h = h,
+            centerX = x + w / 2,
+            centerY = y + h / 2,
+            rect = Rect(x, y, x + w, y + h)
+        )
+    }
+
+    private fun identityAnnotationMap(vararg pairs: Pair<ScaledBox, String>): Map<ScaledBox, String> {
+        return object : AbstractMap<ScaledBox, String>() {
+            override val entries: Set<Map.Entry<ScaledBox, String>> = object : AbstractSet<Map.Entry<ScaledBox, String>>() {
+                override val size: Int = pairs.size
+
+                override fun iterator(): Iterator<Map.Entry<ScaledBox, String>> {
+                    return pairs.map { (key, value) ->
+                        object : Map.Entry<ScaledBox, String> {
+                            override val key: ScaledBox = key
+                            override val value: String = value
+                        }
+                    }.iterator()
+                }
+            }
+
+            override fun get(key: ScaledBox): String? {
+                return pairs.firstOrNull { (candidate, _) ->
+                    candidate === key || candidate.sameTestBoxAs(key)
+                }?.second
+            }
+        }
+    }
+
+    private fun ScaledBox.sameTestBoxAs(other: ScaledBox): Boolean {
+        return label == other.label &&
+            text == other.text &&
+            x == other.x &&
+            y == other.y &&
+            w == other.w &&
+            h == other.h
     }
 }


### PR DESCRIPTION
## Description

Fixes the Sketch-to-UI metadata association flow so OCR annotations are correctly applied to detected widgets. The change separates canvas detections from margin metadata, preserves margin annotations, normalizes OCR attribute values, and prevents invalid blank widget tags from interfering with XML generation.

This resolves the incorrect fallback ImageView ID, missing `layout_gravity`, duplicated tag text being rendered as Switch text, and ghost widget-tag detections.

## Details

Focused tests were added/updated for metadata parsing, widget-tag filtering, ImageView metadata recovery, Switch label preservation, and screenshot-like XML generation.

### Sketch Tested

<img width="1079" height="1382" alt="UI_sketch_7_0" src="https://github.com/user-attachments/assets/498fcda4-34ea-4f8b-b10a-813dfc158b10" />

### Before

https://github.com/user-attachments/assets/31421f19-ed02-4ae5-a655-27b014291d05

### After

https://github.com/user-attachments/assets/4ee9afac-e25f-4533-90cf-8c23c6e0ff5a

## Ticket

[ADFA-4038](https://appdevforall.atlassian.net/browse/ADFA-4038)


[ADFA-4038]: https://appdevforall.atlassian.net/browse/ADFA-4038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ