### PR TITLE
ADFA-4118 | Fix Sketch to UI dropdown generation

### DIFF
--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/GenericBoxResolver.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/GenericBoxResolver.kt
@@ -2,19 +2,27 @@ package org.appdevforall.codeonthego.computervision.domain
 
 import android.graphics.RectF
 import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
-import kotlin.math.hypot
 
 class GenericBoxResolver {
+    private companion object {
+        const val MIN_DROPDOWN_SYMBOL_SCORE = 0.70f
+        private const val SYMBOL_BOX_MARGIN_FACTOR = 0.20f
+        private const val SYMBOL_VERTICAL_MARGIN_FACTOR = 0.35f
+        private const val LEFT_EDGE_ZONE_END = 0.40f
+        private const val RIGHT_EDGE_ZONE_START = 0.60f
+    }
 
     fun resolve(detections: List<DetectionResult>): List<DetectionResult> {
-        val dropdownSymbols = detections.filter { it.label == "dropdown_symbol" }
+        val dropdownSymbols = detections.filter {
+            it.label == "dropdown_symbol" && it.score >= MIN_DROPDOWN_SYMBOL_SCORE
+        }
 
         return detections.mapNotNull { det ->
             when (det.label) {
                 "dropdown_symbol" -> null
                 "generic_box" -> {
                     val hasSymbolNearby = dropdownSymbols.any { symbol ->
-                        isNearby(det.boundingBox, symbol.boundingBox, 0.8f)
+                        isAcceptedDropdownSymbol(det.boundingBox, symbol.boundingBox)
                     }
                     det.copy(label = if (hasSymbolNearby) "dropdown" else "text_entry_box")
                 }
@@ -23,15 +31,21 @@ class GenericBoxResolver {
         }
     }
 
-    private fun isNearby(box1: RectF, box2: RectF, thresholdFactor: Float = 1.5f): Boolean {
-        val avgDim1 = (box1.width() + box1.height()) / 2f
-        val distanceThreshold = thresholdFactor * avgDim1
+    private fun isAcceptedDropdownSymbol(box: RectF, symbol: RectF): Boolean {
+        val boxWidth = box.right - box.left
+        val boxHeight = box.bottom - box.top
+        val symbolCenterX = (symbol.left + symbol.right) / 2f
+        val symbolCenterY = (symbol.top + symbol.bottom) / 2f
 
-        val distance = hypot(
-            (box1.centerX() - box2.centerX()).toDouble(),
-            (box1.centerY() - box2.centerY()).toDouble()
-        ).toFloat()
+        val horizontalMargin = boxWidth * SYMBOL_BOX_MARGIN_FACTOR
+        val verticalMargin = boxHeight * SYMBOL_VERTICAL_MARGIN_FACTOR
 
-        return distance < distanceThreshold
+        val centerInsideOrVeryClose = symbolCenterX in (box.left - horizontalMargin)..(box.right + horizontalMargin) &&
+            symbolCenterY in (box.top - verticalMargin)..(box.bottom + verticalMargin)
+        if (!centerInsideOrVeryClose) return false
+
+        val leftEdgeZoneEnd = box.left + (boxWidth * LEFT_EDGE_ZONE_END)
+        val rightEdgeZoneStart = box.left + (boxWidth * RIGHT_EDGE_ZONE_START)
+        return symbolCenterX <= leftEdgeZoneEnd || symbolCenterX >= rightEdgeZoneStart
     }
 }

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/grammar/WidgetGrammar.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/grammar/WidgetGrammar.kt
@@ -57,6 +57,7 @@ interface CompoundButtonGrammar : TextGrammar {
 object SpinnerGrammar : LayoutGrammar {
     override val tag = "Spinner"
     override val attributes = super.attributes + mapOf(
+        AttributeKey.ID.xmlName to PassThroughValidator,
         AttributeKey.TEXT.xmlName to PassThroughValidator,
         AttributeKey.ENTRIES.xmlName to EntriesValidator
     )

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/FuzzyAttributeParser.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/FuzzyAttributeParser.kt
@@ -105,7 +105,7 @@ object FuzzyAttributeParser {
         val currentValue = StringBuilder()
 
         for (token in tokens) {
-            val matchedKey = if (shouldTreatTokenAsValue(token, currentKey)) {
+            val matchedKey = if (shouldTreatTokenAsValue(token, currentKey, currentValue)) {
                 null
             } else {
                 fuzzyMatchKey(token)
@@ -124,10 +124,17 @@ object FuzzyAttributeParser {
         return result
     }
 
-    private fun shouldTreatTokenAsValue(token: String, currentKey: AttributeKey?): Boolean {
+    private fun shouldTreatTokenAsValue(
+        token: String,
+        currentKey: AttributeKey?,
+        currentValue: StringBuilder
+    ): Boolean {
         val lowerToken = token.trim().lowercase()
 
         return when {
+            currentKey == AttributeKey.ID &&
+                currentValue.isBlank() &&
+                AttributeKey.findByAlias(normalizeKeyToken(token)) == null -> true
             currentKey == AttributeKey.INPUT_TYPE && lowerToken in inputTypeValues -> true
             currentKey in setOf(AttributeKey.LAYOUT_GRAVITY, AttributeKey.GRAVITY) && lowerToken in GravityValueSet.values -> true
             currentKey?.valueType == ValueType.COLOR && isColorToken(lowerToken) -> true
@@ -163,13 +170,7 @@ object FuzzyAttributeParser {
     }
 
     private fun fuzzyMatchKey(rawKey: String): AttributeKey? {
-        val normalizedKey = rawKey.lowercase()
-            .replace("-", "_")
-            .replace(Regex("\\s+"), "_")
-            .replace(".", "_")
-            .replace(multipleUnderscoresRegex, "_")
-            .replace(Regex("lay[ao0]ut"), "layout")
-            .replace(Regex("(?<=^|_)[lt]d(?=$|_)"), "id")
+        val normalizedKey = normalizeKeyToken(rawKey)
 
         val exactMatch = AttributeKey.findByAlias(normalizedKey)
         if (exactMatch != null) return exactMatch
@@ -185,6 +186,16 @@ object FuzzyAttributeParser {
         val result = FuzzySearch.extractOne(normalizedKey, AttributeKey.allAliases)
 
         return if (result.score >= threshold) AttributeKey.findByAlias(result.string) else null
+    }
+
+    private fun normalizeKeyToken(rawKey: String): String {
+        return rawKey.lowercase()
+            .replace("-", "_")
+            .replace(Regex("\\s+"), "_")
+            .replace(".", "_")
+            .replace(multipleUnderscoresRegex, "_")
+            .replace(Regex("lay[ao0]ut"), "layout")
+            .replace(Regex("(?<=^|_)[lt]d(?=$|_)"), "id")
     }
 
     private fun resolveXmlAttribute(key: AttributeKey, value: String, tag: String): Pair<String, String> {

--- a/sketch-to-ui-plugin/src/main/kotlin/com/appdevforall/sketchtoui/plugin/GeneratedStringsWriter.kt
+++ b/sketch-to-ui-plugin/src/main/kotlin/com/appdevforall/sketchtoui/plugin/GeneratedStringsWriter.kt
@@ -15,15 +15,7 @@ class GeneratedStringsWriter(
         val stringsFile = File(projectRoot, STRINGS_XML_RELATIVE_PATH)
         val existing = service.readFile(stringsFile)
 
-        val updated = if (existing.isNullOrBlank()) {
-            "<resources>\n${stringsXml.trim().prependIndent("    ")}\n</resources>\n"
-        } else {
-            val insertionPoint = existing.lastIndexOf("</resources>")
-            if (insertionPoint < 0) return false
-            existing.take(insertionPoint).trimEnd() +
-                "\n${stringsXml.trim().prependIndent("    ")}\n" +
-                existing.substring(insertionPoint)
-        }
+        val updated = GeneratedStringArrayMerger.merge(existing, stringsXml) ?: return false
 
         return service.writeFile(stringsFile, updated)
     }
@@ -31,4 +23,142 @@ class GeneratedStringsWriter(
     private companion object {
         const val STRINGS_XML_RELATIVE_PATH = "app/src/main/res/values/strings.xml"
     }
+}
+
+internal object GeneratedStringArrayMerger {
+    private val stringArrayBlockRegex = Regex(
+        """<string-array\b[^>]*\bname\s*=\s*(['"])([^'"]+)\1[^>]*>.*?</string-array>""",
+        setOf(RegexOption.DOT_MATCHES_ALL)
+    )
+    private val itemRegex = Regex("""<item\b[^>]*>(.*?)</item>""", setOf(RegexOption.DOT_MATCHES_ALL))
+
+    fun merge(existing: String?, generated: String): String? {
+        val generatedArrays = parseStringArrays(generated)
+        if (generatedArrays.isEmpty()) return existing
+
+        val existingXml = existing?.takeIf { it.isNotBlank() }
+            ?: return buildResourcesFile(generatedArrays)
+
+        val result = generatedArrays.fold(MergeState(existingXml)) { state, generatedArray ->
+            state.merge(generatedArray) ?: return null
+        }
+
+        return result.xml.takeIf { result.changed } ?: existingXml
+    }
+
+    private fun buildResourcesFile(arrays: List<StringArrayResource>): String {
+        return "<resources>\n${arrays.joinToString("\n\n") { it.toXmlBlock() }}\n</resources>\n"
+    }
+
+    private fun MergeState.merge(generatedArray: StringArrayResource): MergeState? {
+        val existingBlocks = findStringArrayBlocks(xml, generatedArray.name)
+        return when {
+            existingBlocks.isEmpty() -> append(generatedArray)
+            existingBlocks.shouldReplaceWith(generatedArray) -> replace(existingBlocks, generatedArray)
+            else -> this
+        }
+    }
+
+    private fun MergeState.append(array: StringArrayResource): MergeState? {
+        val insertionPoint = xml.lastIndexOf("</resources>")
+        if (insertionPoint < 0) return null
+
+        val updatedXml = xml.take(insertionPoint).trimEnd() +
+            "\n\n${array.toXmlBlock()}\n" +
+            xml.substring(insertionPoint)
+
+        return copy(xml = updatedXml, changed = true)
+    }
+
+    private fun MergeState.replace(blocks: List<MatchResult>, array: StringArrayResource): MergeState {
+        val replacement = array.toXmlBlock()
+        val updatedXml = blocks.asReversed().foldIndexed(xml) { index, currentXml, block ->
+            if (index == blocks.lastIndex) {
+                currentXml.replaceRange(block.range, replacement)
+            } else {
+                currentXml.removeRangeWithBlankLine(block.range)
+            }
+        }
+
+        return copy(xml = updatedXml, changed = true)
+    }
+
+    private fun List<MatchResult>.shouldReplaceWith(array: StringArrayResource): Boolean {
+        val existingItems = parseStringArrays(first().value).firstOrNull()?.items
+        return existingItems != array.items || size > 1
+    }
+
+    private fun parseStringArrays(xml: String): List<StringArrayResource> {
+        return stringArrayBlockRegex.findAll(xml.wrapInResourcesIfNeeded()).mapNotNull { match ->
+            val name = match.groupValues[2].takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val items = itemRegex.findAll(match.value).map { itemMatch ->
+                itemMatch.groupValues[1].unescapeXmlText()
+            }.toList()
+            StringArrayResource(name, items)
+        }.toList()
+    }
+
+    private fun findStringArrayBlocks(xml: String, name: String): List<MatchResult> {
+        return stringArrayBlockRegex.findAll(xml)
+            .filter { it.groupValues[2] == name }
+            .toList()
+    }
+
+    private fun String.wrapInResourcesIfNeeded(): String {
+        val trimmed = trim()
+        return if (trimmed.startsWith("<resources")) trimmed else "<resources>\n$trimmed\n</resources>"
+    }
+
+    private fun String.unescapeXmlText(): String {
+        return trim()
+            .replace("&apos;", "'")
+            .replace("&quot;", "\"")
+            .replace("&gt;", ">")
+            .replace("&lt;", "<")
+            .replace("&amp;", "&")
+    }
+
+    private fun String.removeRangeWithBlankLine(range: IntRange): String {
+        var start = range.first
+        var endExclusive = range.last + 1
+
+        if (start >= 2 && substring(start - 2, start) == "\n\n") {
+            start -= 2
+        } else if (start >= 1 && this[start - 1] == '\n') {
+            start -= 1
+        }
+
+        if (endExclusive < length && this[endExclusive] == '\n') {
+            endExclusive += 1
+        }
+
+        return removeRange(start, endExclusive)
+    }
+
+    private data class MergeState(
+        val xml: String,
+        val changed: Boolean = false
+    )
+}
+
+private data class StringArrayResource(
+    val name: String,
+    val items: List<String>
+) {
+    fun toXmlBlock(): String {
+        return buildString {
+            appendLine("""    <string-array name="$name">""")
+            items.forEach { item ->
+                appendLine("        <item>${item.escapeXmlText()}</item>")
+            }
+            append("""    </string-array>""")
+        }
+    }
+
+    private fun String.escapeXmlText(): String = trim()
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")
+        .replace("'", "&apos;")
 }

--- a/sketch-to-ui-plugin/src/test/java/com/appdevforall/sketchtoui/plugin/GeneratedStringsWriterTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/com/appdevforall/sketchtoui/plugin/GeneratedStringsWriterTest.kt
@@ -1,0 +1,169 @@
+package com.appdevforall.sketchtoui.plugin
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GeneratedStringsWriterTest {
+
+    @Test
+    fun `adds new string array when missing`() {
+        val existing = """
+            <resources>
+                <string name="app_name">My Application</string>
+            </resources>
+        """.trimIndent()
+        val generated = residenceStateArray()
+
+        val updated = GeneratedStringArrayMerger.merge(existing, generated)
+
+        assertTrue(updated!!.contains("""<string name="app_name">My Application</string>"""))
+        assertEquals(1, Regex("""<string-array name="residencestate_array">""").findAll(updated).count())
+        assertTrue(updated.contains("<item>California</item>"))
+        assertTrue(updated.contains("<item>Oregon</item>"))
+        assertTrue(updated.contains("<item>washington</item>"))
+    }
+
+    @Test
+    fun `adds generated residence state array to app-name-only resources`() {
+        val existing = """
+            <resources>
+                <string name="app_name">My Application</string>
+            </resources>
+        """.trimIndent()
+        val generated = """
+                <string-array name="residencestate_array">
+                    <item>California</item>
+                    <item>Oregon</item>
+                    <item>washington</item>
+                </string-array>
+        """.trimIndent()
+
+        val updated = GeneratedStringArrayMerger.merge(existing, generated)
+
+        assertTrue(updated!!.contains("""<string name="app_name">My Application</string>"""))
+        assertEquals(1, Regex("""<string-array name="residencestate_array">""").findAll(updated).count())
+        assertTrue(updated.contains("<item>California</item>"))
+        assertTrue(updated.contains("<item>Oregon</item>"))
+        assertTrue(updated.contains("<item>washington</item>"))
+    }
+
+    @Test
+    fun `spinner layout array reference has matching saved string array`() {
+        val layoutXml = """
+            <Spinner
+                android:id="@+id/residencestate"
+                android:layout_width="150dp"
+                android:layout_height="75dp"
+                android:entries="@array/residencestate_array" />
+        """.trimIndent()
+        val existing = """
+            <resources>
+                <string name="app_name">My Application</string>
+            </resources>
+        """.trimIndent()
+
+        val updated = GeneratedStringArrayMerger.merge(existing, residenceStateArray())
+
+        assertTrue(layoutXml.contains("""android:entries="@array/residencestate_array""""))
+        assertTrue(updated!!.contains("""<string-array name="residencestate_array">"""))
+    }
+
+    @Test
+    fun `does not duplicate existing string array with same items`() {
+        val existing = """
+            <resources>
+                <string name="app_name">My Application</string>
+
+                <string-array name="residencestate_array">
+                    <item>California</item>
+                    <item>Oregon</item>
+                    <item>washington</item>
+                </string-array>
+            </resources>
+        """.trimIndent()
+
+        val updated = GeneratedStringArrayMerger.merge(existing, residenceStateArray())
+
+        assertEquals(existing, updated)
+        assertEquals(1, Regex("""<string-array name="residencestate_array">""").findAll(updated!!).count())
+    }
+
+    @Test
+    fun `updates existing string array with different items without duplicating`() {
+        val existing = """
+            <resources>
+                <string name="app_name">My Application</string>
+
+                <string-array name="residencestate_array">
+                    <item>California</item>
+                    <item>Oregon</item>
+                </string-array>
+            </resources>
+        """.trimIndent()
+
+        val updated = GeneratedStringArrayMerger.merge(existing, residenceStateArray())
+
+        assertTrue(updated!!.contains("""<string name="app_name">My Application</string>"""))
+        assertEquals(1, Regex("""<string-array name="residencestate_array">""").findAll(updated).count())
+        assertTrue(updated.contains("<item>washington</item>"))
+    }
+
+    @Test
+    fun `removes duplicate existing string arrays with same name`() {
+        val existing = """
+            <resources>
+                <string-array name="residencestate_array">
+                    <item>California</item>
+                    <item>Oregon</item>
+                    <item>washington</item>
+                </string-array>
+
+                <string-array name="residencestate_array">
+                    <item>California</item>
+                    <item>Oregon</item>
+                    <item>washington</item>
+                </string-array>
+            </resources>
+        """.trimIndent()
+
+        val updated = GeneratedStringArrayMerger.merge(existing, residenceStateArray())
+
+        assertEquals(1, Regex("""<string-array name="residencestate_array">""").findAll(updated!!).count())
+    }
+
+    @Test
+    fun `preserves unrelated resources while merging string arrays`() {
+        val existing = """
+            <resources>
+                <string name="app_name">My Application</string>
+                <plurals name="message_count">
+                    <item quantity="one">%d message</item>
+                    <item quantity="other">%d messages</item>
+                </plurals>
+                <string-array name="other_array">
+                    <item>Existing</item>
+                </string-array>
+            </resources>
+        """.trimIndent()
+
+        val updated = GeneratedStringArrayMerger.merge(existing, residenceStateArray())
+
+        assertTrue(updated!!.contains("""<string name="app_name">My Application</string>"""))
+        assertTrue(updated.contains("""<plurals name="message_count">"""))
+        assertTrue(updated.contains("""<string-array name="other_array">"""))
+        assertTrue(updated.contains("""<string-array name="residencestate_array">"""))
+        assertFalse(updated.contains("""<resources><resources>"""))
+    }
+
+    private fun residenceStateArray(): String {
+        return """
+            <string-array name="residencestate_array">
+                <item>California</item>
+                <item>Oregon</item>
+                <item>washington</item>
+            </string-array>
+        """.trimIndent()
+    }
+}

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParserTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParserTest.kt
@@ -122,6 +122,15 @@ class FuzzyAttributeParserTest {
     }
 
     @Test
+    fun `id value does not swallow following noisy key`() {
+        val annotation = "id:my_input textcalar black"
+        val result = FuzzyAttributeParser.parse(annotation, "TextView")
+
+        assertEquals("my_input", result["android:id"])
+        assertEquals("#000000", result["android:textColor"])
+    }
+
+    @Test
     fun `invalid textColor is omitted`() {
         val annotation = "textcolor: group1 | width: 100dp"
         val result = FuzzyAttributeParser.parse(annotation, "CheckBox")
@@ -315,11 +324,22 @@ class FuzzyAttributeParserTest {
     }
 
     @Test
-    fun `entries attribute maps to tools namespace`() {
+    fun `entries attribute maps to android namespace`() {
         val annotation = "entries: @array/items | width: 100dp"
         val result = FuzzyAttributeParser.parse(annotation, "Spinner")
 
-        assertEquals("@array/items", result["tools:entries"])
+        assertEquals("@array/items", result["android:entries"])
+    }
+
+    @Test
+    fun `spinner id width height and entries parse correctly`() {
+        val annotation = "width:150dp height:75dp id:residencestate entries:[California,Oregon,washington]"
+        val result = FuzzyAttributeParser.parse(annotation, "Spinner")
+
+        assertEquals("residencestate", result["android:id"])
+        assertEquals("150dp", result["android:layout_width"])
+        assertEquals("75dp", result["android:layout_height"])
+        assertEquals("California,Oregon,washington", result["android:entries"])
     }
 
     @Test

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/GenericBoxResolverTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/GenericBoxResolverTest.kt
@@ -1,0 +1,73 @@
+package org.appdevforall.codeonthego.computervision.domain
+
+import android.graphics.RectF
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GenericBoxResolverTest {
+
+    private val resolver = GenericBoxResolver()
+
+    @Test
+    fun `generic box with high confidence dropdown symbol near right edge becomes dropdown`() {
+        val result = resolver.resolve(
+            listOf(
+                detection("generic_box", left = 100f, top = 100f, right = 300f, bottom = 150f),
+                detection("dropdown_symbol", left = 265f, top = 115f, right = 285f, bottom = 135f, score = 0.95f)
+            )
+        )
+
+        assertEquals(listOf("dropdown"), result.map { it.label })
+    }
+
+    @Test
+    fun `generic box with high confidence dropdown symbol near left edge becomes dropdown`() {
+        val result = resolver.resolve(
+            listOf(
+                detection("generic_box", left = 100f, top = 100f, right = 300f, bottom = 150f),
+                detection("dropdown_symbol", left = 115f, top = 115f, right = 135f, bottom = 135f, score = 0.95f)
+            )
+        )
+
+        assertEquals(listOf("dropdown"), result.map { it.label })
+    }
+
+    @Test
+    fun `generic box with low confidence dropdown symbol near left edge remains text entry box`() {
+        val result = resolver.resolve(
+            listOf(
+                detection("generic_box", left = 100f, top = 100f, right = 300f, bottom = 150f),
+                detection("dropdown_symbol", left = 115f, top = 115f, right = 135f, bottom = 135f, score = 0.33f)
+            )
+        )
+
+        assertEquals(listOf("text_entry_box"), result.map { it.label })
+    }
+
+    @Test
+    fun `generic box with no dropdown symbol remains text entry box`() {
+        val result = resolver.resolve(
+            listOf(
+                detection("generic_box", left = 100f, top = 100f, right = 300f, bottom = 150f)
+            )
+        )
+
+        assertEquals(listOf("text_entry_box"), result.map { it.label })
+    }
+
+    private fun detection(
+        label: String,
+        left: Float,
+        top: Float,
+        right: Float,
+        bottom: Float,
+        score: Float = 0.99f
+    ): DetectionResult {
+        return DetectionResult(
+            boundingBox = RectF(left, top, right, bottom),
+            label = label,
+            score = score
+        )
+    }
+}

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/xml/LayoutRendererTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/xml/LayoutRendererTest.kt
@@ -172,6 +172,34 @@ class LayoutRendererTest {
         assertFalse(xml.contains("""android:id="@+id/im_view_1""""))
     }
 
+    @Test
+    fun `spinner annotation id is used for widget id and generated entries array`() {
+        val dropdown = box("dropdown", "StateofResidence", x = 0, y = 0, w = 260, h = 52)
+        val context = XmlContext()
+
+        val renderer = LayoutRenderer(
+            context = context,
+            annotations = mapOf(
+                dropdown to "width:150dp height:75dp id:residencestate entries:[California,Oregon,washington]"
+            )
+        )
+
+        renderer.render(LayoutItem.SimpleView(dropdown))
+
+        val xml = context.toString()
+
+        assertTrue(xml.contains("""<TextView"""))
+        assertTrue(xml.contains("""android:text="StateofResidence""""))
+        assertTrue(xml.contains("""<Spinner"""))
+        assertTrue(xml.contains("""android:id="@+id/residencestate""""))
+        assertTrue(xml.contains("""android:layout_width="150dp""""))
+        assertTrue(xml.contains("""android:layout_height="75dp""""))
+        assertTrue(xml.contains("""android:entries="@array/residencestate_array""""))
+        assertEquals(listOf("California", "Oregon", "washington"), context.stringArrays["residencestate_array"])
+        assertFalse(xml.contains("""android:id="@+id/spinner_0""""))
+        assertFalse(xml.contains("""android:entries="@array/spinner_0_array""""))
+    }
+
     private fun checkboxBox(y: Int, text: String, checked: Boolean = false): ScaledBox {
         val label = if (checked) "checkbox_checked" else "checkbox_unchecked"
         return ScaledBox(


### PR DESCRIPTION
## Description

Fixed Sketch to UI dropdown generation by improving generic box resolution, preserving parsed Spinner IDs, and ensuring generated Spinner entries are correctly written to `strings.xml`.

The change prevents low-confidence dropdown symbols from incorrectly converting text fields into Spinners, supports valid dropdown indicators on both left and right sides, and keeps generated string arrays idempotent across repeated saves.

## Details

* Improved `GenericBoxResolver` to avoid false dropdown classification.
* Preserved parsed Spinner IDs such as `residencestate`.
* Ensured Spinner entries use the resolved ID-based array name.
* Updated string-array writing to avoid duplicate resources.
* Added regression coverage for dropdown resolution, Spinner parsing/rendering, and string-array merging.
* Cleaned up parser handling so ID values do not swallow following noisy attribute keys.


https://github.com/user-attachments/assets/315f60b4-5051-44d7-abe1-95ce2ea47346


## Ticket

[ADFA-4118](https://appdevforall.atlassian.net/browse/ADFA-4118)

[ADFA-4118]: https://appdevforall.atlassian.net/browse/ADFA-4118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ