### PR TITLE
ADFA-4278 | Fix radio and checkbox grouping

### DIFF
--- a/sketch-to-ui-plugin/build.gradle.kts
+++ b/sketch-to-ui-plugin/build.gradle.kts
@@ -14,6 +14,23 @@ android {
     namespace = "com.appdevforall.sketchtoui.plugin"
     compileSdk = 35
 
+    sourceSets {
+        getByName("main") {
+            java.srcDirs(
+                "src/main/java",
+                "src/main/kotlin"
+            )
+        }
+
+        getByName("test") {
+            java.srcDirs(
+                "src/test/java",
+                "src/test/kotlin",
+                "test/java"
+            )
+        }
+    }
+
     defaultConfig {
         applicationId = "com.appdevforall.sketchtoui.plugin"
         minSdk = 28

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/GenericBoxResolver.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/GenericBoxResolver.kt
@@ -1,6 +1,7 @@
 package org.appdevforall.codeonthego.computervision.domain
 
 import android.graphics.RectF
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionLabels
 import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
 
 class GenericBoxResolver {
@@ -14,17 +15,17 @@ class GenericBoxResolver {
 
     fun resolve(detections: List<DetectionResult>): List<DetectionResult> {
         val dropdownSymbols = detections.filter {
-            it.label == "dropdown_symbol" && it.score >= MIN_DROPDOWN_SYMBOL_SCORE
+            it.label == DetectionLabels.DROPDOWN_SYMBOL && it.score >= MIN_DROPDOWN_SYMBOL_SCORE
         }
 
         return detections.mapNotNull { det ->
             when (det.label) {
-                "dropdown_symbol" -> null
-                "generic_box" -> {
+                DetectionLabels.DROPDOWN_SYMBOL -> null
+                DetectionLabels.GENERIC_BOX -> {
                     val hasSymbolNearby = dropdownSymbols.any { symbol ->
                         isAcceptedDropdownSymbol(det.boundingBox, symbol.boundingBox)
                     }
-                    det.copy(label = if (hasSymbolNearby) "dropdown" else "text_entry_box")
+                    det.copy(label = if (hasSymbolNearby) DetectionLabels.DROPDOWN else DetectionLabels.TEXT_ENTRY_BOX)
                 }
                 else -> det
             }

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/LayoutTreeBuilder.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/LayoutTreeBuilder.kt
@@ -1,5 +1,6 @@
 package org.appdevforall.codeonthego.computervision.domain
 
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionLabels
 import org.appdevforall.codeonthego.computervision.domain.model.LayoutItem
 import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
 import kotlin.math.abs
@@ -101,11 +102,9 @@ object LayoutTreeBuilder {
         return rows.sortedBy { it.top }.map { it.boxes.sortedBy(ScaledBox::x) }
     }
 
-    private fun isRadioButton(box: ScaledBox): Boolean =
-        box.label == "radio_button_unchecked" || box.label == "radio_button_checked"
+    private fun isRadioButton(box: ScaledBox): Boolean = DetectionLabels.isRadioButton(box.label)
 
-    private fun isCheckbox(box: ScaledBox): Boolean =
-        box.label == "checkbox_unchecked" || box.label == "checkbox_checked"
+    private fun isCheckbox(box: ScaledBox): Boolean = DetectionLabels.isCheckbox(box.label)
 
     private class LayoutRow(initialBox: ScaledBox) {
         private val _boxes = mutableListOf(initialBox)

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/LayoutTreeBuilder.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/LayoutTreeBuilder.kt
@@ -13,6 +13,8 @@ import kotlin.math.max
 object LayoutTreeBuilder {
     private const val OVERLAP_THRESHOLD = 0.6
     private const val VERTICAL_ALIGN_THRESHOLD = 20
+    private const val SAME_COLUMN_X_THRESHOLD = 24
+    private const val MIN_HORIZONTAL_GAP = 24
 
     fun buildLayoutTree(boxes: List<ScaledBox>): List<LayoutItem> {
         val rows = groupIntoRows(boxes)
@@ -39,10 +41,16 @@ object LayoutTreeBuilder {
             if (!isCheckboxRow && verticalCheckboxRun.isNotEmpty()) flushRuns()
 
             when {
-                isRadioRow && row.size == 1 -> verticalRadioRun.add(row.first())
-                isRadioRow -> items.add(LayoutItem.RadioGroup(row, "horizontal"))
-                isCheckboxRow && row.size == 1 -> verticalCheckboxRun.add(row.first())
-                isCheckboxRow -> items.add(LayoutItem.CheckboxGroup(row, "horizontal"))
+                isRadioRow && shouldTreatAsVerticalRun(row) -> verticalRadioRun.addAll(row.sortedBy { it.y })
+                isRadioRow -> {
+                    flushRuns()
+                    items.add(LayoutItem.RadioGroup(row.sortedBy { it.x }, "horizontal"))
+                }
+                isCheckboxRow && shouldTreatAsVerticalRun(row) -> verticalCheckboxRun.addAll(row.sortedBy { it.y })
+                isCheckboxRow -> {
+                    flushRuns()
+                    items.add(LayoutItem.CheckboxGroup(row.sortedBy { it.x }, "horizontal"))
+                }
                 else -> {
                     flushRuns()
                     if (row.size == 1) {
@@ -56,6 +64,26 @@ object LayoutTreeBuilder {
         flushRuns()
 
         return items
+    }
+
+    private fun shouldTreatAsVerticalRun(row: List<ScaledBox>): Boolean {
+        if (row.size == 1) return true
+
+        val sortedByY = row.sortedBy { it.y }
+        val minX = row.minOf { it.x }
+        val maxX = row.maxOf { it.x }
+        val sameColumn = maxX - minX <= SAME_COLUMN_X_THRESHOLD
+
+        if (sameColumn) return true
+
+        val hasRealHorizontalSpacing = sortedByY
+            .zipWithNext()
+            .all { (current, next) ->
+                val horizontalGap = next.x - (current.x + current.w)
+                horizontalGap >= MIN_HORIZONTAL_GAP
+            }
+
+        return !hasRealHorizontalSpacing
     }
 
     private fun groupIntoRows(boxes: List<ScaledBox>): List<List<ScaledBox>> {

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/RegionOcrProcessor.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/RegionOcrProcessor.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import org.appdevforall.codeonthego.computervision.data.source.OcrSource
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionLabels
 import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
 import org.appdevforall.codeonthego.computervision.domain.model.MetadataOcrSource
 import org.appdevforall.codeonthego.computervision.domain.model.SketchRegion
@@ -19,18 +20,18 @@ class RegionOcrProcessor(
 ) {
 
     private val interactiveLabels = setOf(
-        "button",
-        "switch_on",
-        "switch_off",
-        "text_entry_box",
-        "dropdown",
-        "checkbox_checked",
-        "checkbox_unchecked",
-        "radio_button_checked",
-        "radio_button_unchecked",
-        "slider",
-        "image_placeholder",
-        "widget_tag"
+        DetectionLabels.BUTTON,
+        DetectionLabels.SWITCH_ON,
+        DetectionLabels.SWITCH_OFF,
+        DetectionLabels.TEXT_ENTRY_BOX,
+        DetectionLabels.DROPDOWN,
+        DetectionLabels.CHECKBOX_CHECKED,
+        DetectionLabels.CHECKBOX_UNCHECKED,
+        DetectionLabels.RADIO_BUTTON_CHECKED,
+        DetectionLabels.RADIO_BUTTON_UNCHECKED,
+        DetectionLabels.SLIDER,
+        DetectionLabels.IMAGE_PLACEHOLDER,
+        DetectionLabels.WIDGET_TAG
     )
 
     data class RegionOcrResult(
@@ -128,7 +129,7 @@ class RegionOcrProcessor(
                                 box.right + offsetX,
                                 box.bottom + rect.top
                             ),
-                            label = "text",
+                            label = DetectionLabels.TEXT,
                             score = 0.99f,
                             text = OcrTextAssembler.joinElementsWithTolerance(line),
                             isYolo = false,

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/TextAssociator.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/TextAssociator.kt
@@ -1,5 +1,6 @@
 package org.appdevforall.codeonthego.computervision.domain
 
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionLabels
 import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
 import org.appdevforall.codeonthego.computervision.utils.TextCleaner.cleanTextPreservingLeadingO
 import org.appdevforall.codeonthego.computervision.utils.TextCleaner.cleanTextStrippingLeadingO
@@ -68,11 +69,9 @@ object TextAssociator {
     }
 
     private fun isLabelableWidget(box: ScaledBox): Boolean {
-        return box.label in setOf(
-            "radio_button_unchecked", "radio_button_checked",
-            "checkbox_unchecked", "checkbox_checked",
-            "switch_on", "switch_off"
-        )
+        return DetectionLabels.isRadioButton(box.label) ||
+            DetectionLabels.isCheckbox(box.label) ||
+            DetectionLabels.isSwitch(box.label)
     }
 
     private fun cleanWidgetText(widget: ScaledBox, rawText: String): String {

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetAnnotationMatcher.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetAnnotationMatcher.kt
@@ -1,6 +1,9 @@
 package org.appdevforall.codeonthego.computervision.domain
 
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionLabels
 import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+import org.appdevforall.codeonthego.computervision.domain.model.WidgetTypes
+import org.appdevforall.codeonthego.computervision.domain.widgettag.WidgetTagPrefixes
 import java.util.Collections
 import java.util.IdentityHashMap
 
@@ -72,28 +75,31 @@ class WidgetAnnotationMatcher {
 
     private fun getTagType(tag: String): String? {
         return when {
-            tag.startsWith("B-") -> "button"
-            tag.startsWith("P-") -> "image_placeholder"
-            tag.startsWith("D-") -> "dropdown"
-            tag.startsWith("T-") -> "text_entry_box"
-            tag.startsWith("C-") -> "checkbox"
-            tag.startsWith("R-") -> "radio"
-            tag.startsWith("SW-") -> "switch"
-            tag.startsWith("S-") -> "slider"
+            tag.startsWith(WidgetTagPrefixes.BUTTON) -> WidgetTypes.BUTTON
+            tag.startsWith(WidgetTagPrefixes.IMAGE_PLACEHOLDER) -> WidgetTypes.IMAGE_PLACEHOLDER
+            tag.startsWith(WidgetTagPrefixes.DROPDOWN) -> WidgetTypes.DROPDOWN
+            tag.startsWith(WidgetTagPrefixes.TEXT_ENTRY) -> WidgetTypes.TEXT_ENTRY_BOX
+            tag.startsWith(WidgetTagPrefixes.CHECKBOX) -> WidgetTypes.CHECKBOX
+            tag.startsWith(WidgetTagPrefixes.RADIO) -> WidgetTypes.RADIO
+            tag.startsWith(WidgetTagPrefixes.SWITCH) -> WidgetTypes.SWITCH
+            tag.startsWith(WidgetTagPrefixes.SLIDER) -> WidgetTypes.SLIDER
             else -> null
         }
     }
 
-    private fun normalizeWidgetType(label: String): String = when {
-        label.startsWith("text_entry_box") -> "text_entry_box"
-        label.startsWith("button") -> "button"
-        label.startsWith("switch") -> "switch"
-        label.startsWith("checkbox") -> "checkbox"
-        label.startsWith("radio") -> "radio"
-        label.startsWith("dropdown") -> "dropdown"
-        label.startsWith("slider") -> "slider"
-        label.startsWith("image_placeholder") || label.startsWith("icon") -> "image_placeholder"
-        else -> label
+    private fun normalizeWidgetType(label: String): String {
+        return when {
+            label.startsWith(DetectionLabels.TEXT_ENTRY_BOX_PREFIX) -> WidgetTypes.TEXT_ENTRY_BOX
+            label.startsWith(DetectionLabels.BUTTON_PREFIX) -> WidgetTypes.BUTTON
+            label.startsWith(DetectionLabels.SWITCH_PREFIX) -> WidgetTypes.SWITCH
+            label.startsWith(DetectionLabels.CHECKBOX_PREFIX) -> WidgetTypes.CHECKBOX
+            label.startsWith(DetectionLabels.RADIO_BUTTON_PREFIX) -> WidgetTypes.RADIO
+            label.startsWith(DetectionLabels.DROPDOWN_PREFIX) -> WidgetTypes.DROPDOWN
+            label.startsWith(DetectionLabels.SLIDER_PREFIX) -> WidgetTypes.SLIDER
+            label.startsWith(DetectionLabels.IMAGE_PLACEHOLDER_PREFIX) ||
+                label.startsWith(DetectionLabels.ICON_PREFIX) -> WidgetTypes.IMAGE_PLACEHOLDER
+            else -> label
+        }
     }
 
     private fun findWidgetByOrdinalOrFallback(

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/YoloToXmlConverter.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/YoloToXmlConverter.kt
@@ -1,17 +1,24 @@
 package org.appdevforall.codeonthego.computervision.domain
 
+import org.appdevforall.codeonthego.computervision.domain.converter.CanvasTagExtractor
+import org.appdevforall.codeonthego.computervision.domain.converter.CompoundButtonNormalizer
+import org.appdevforall.codeonthego.computervision.domain.converter.ImagePlaceholderDuplicateFilter
+import org.appdevforall.codeonthego.computervision.domain.converter.TextAssociationProcessor
+import org.appdevforall.codeonthego.computervision.domain.converter.UiCandidateExtractor
 import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
 import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
-import org.appdevforall.codeonthego.computervision.domain.model.SketchRegion
 import org.appdevforall.codeonthego.computervision.domain.xml.AndroidXmlGenerator
-import org.appdevforall.codeonthego.computervision.utils.MetadataDetector
 import org.appdevforall.codeonthego.computervision.utils.buildPlaceholderOverrides
 import kotlin.comparisons.compareBy
-import kotlin.math.abs
 
 class YoloToXmlConverter(
     private val annotationMatcher: WidgetAnnotationMatcher,
-    private val xmlGenerator: AndroidXmlGenerator
+    private val xmlGenerator: AndroidXmlGenerator,
+    private val uiCandidateExtractor: UiCandidateExtractor = UiCandidateExtractor(),
+    private val canvasTagExtractor: CanvasTagExtractor = CanvasTagExtractor(annotationMatcher),
+    private val textAssociationProcessor: TextAssociationProcessor = TextAssociationProcessor(annotationMatcher),
+    private val compoundButtonNormalizer: CompoundButtonNormalizer = CompoundButtonNormalizer(),
+    private val imagePlaceholderDuplicateFilter: ImagePlaceholderDuplicateFilter = ImagePlaceholderDuplicateFilter()
 ) {
     fun generateXmlLayout(
         detections: List<DetectionResult>,
@@ -23,48 +30,49 @@ class YoloToXmlConverter(
         targetDpHeight: Int,
         wrapInScroll: Boolean = true
     ): Pair<String, String> {
-        // 1. Filter and prepare base UI candidates
-        val uiCandidates = extractUiCandidates(detections)
+        val uiCandidates = uiCandidateExtractor.extract(detections)
 
-        // 2. Scale detections to target DP dimensions
         val scaledBoxes = scaleDetections(
-            uiCandidates,
-            sourceImageWidth,
-            sourceImageHeight,
-            targetDpWidth,
-            targetDpHeight
+            candidates = uiCandidates,
+            sourceWidth = sourceImageWidth,
+            sourceHeight = sourceImageHeight,
+            targetWidth = targetDpWidth,
+            targetHeight = targetDpHeight
         )
 
-        // 3. Extract and scale reference tags before text association.
-        // This allows checkbox/radio normalization to use C-* and R-* context.
-        val canvasTags = extractCanvasTags(
-            detections,
-            sourceImageWidth,
-            sourceImageHeight,
-            targetDpWidth,
-            targetDpHeight
+        val canvasTags = canvasTagExtractor.extract(
+            detections = detections,
+            sourceWidth = sourceImageWidth,
+            sourceHeight = sourceImageHeight,
+            targetWidth = targetDpWidth,
+            targetHeight = targetDpHeight
         )
 
-        // 4. Normalize noisy checkbox/radio detections before text association and layout grouping
-        val normalizedBoxes = normalizeCompoundButtonsByNearestTag(scaledBoxes, canvasTags)
+        val normalizedBoxes = compoundButtonNormalizer.normalizeByNearestTag(
+            boxes = scaledBoxes,
+            canvasTags = canvasTags
+        )
 
-        // 5. Associate isolated text detections to their respective UI widgets
-        val associatedBoxes = associateTextToWidgets(normalizedBoxes)
+        val associatedBoxes = textAssociationProcessor.associateText(normalizedBoxes)
+        val uiElements = textAssociationProcessor.finalizeUiElements(associatedBoxes)
 
-        // 6. Clean up and finalize the UI elements list
-        val uiElements = finalizeUiElements(associatedBoxes)
+        val finalAnnotations = annotationMatcher.matchAnnotationsToElements(
+            canvasTags = canvasTags,
+            uiElements = uiElements,
+            annotations = annotations
+        )
 
-        // 7. Match margin annotations with the extracted UI elements
-        val finalAnnotations = annotationMatcher.matchAnnotationsToElements(canvasTags, uiElements, annotations)
-        val filteredUiElements = filterLikelyDuplicateImagePlaceholders(uiElements, finalAnnotations)
+        val filteredUiElements = imagePlaceholderDuplicateFilter.filter(
+            uiElements = uiElements,
+            annotations = finalAnnotations
+        )
 
-        // 8. Sort boxes top-to-bottom, left-to-right for sequential XML rendering
         val sortedBoxes = filteredUiElements.sortedWith(compareBy({ it.y }, { it.x }))
 
-        // 9. Prepare local drawable resources overrides for image placeholders
-        val selectedImageOverrides = filteredUiElements.buildPlaceholderOverrides(selectedImagesByPlaceholderId)
+        val selectedImageOverrides = filteredUiElements.buildPlaceholderOverrides(
+            selectedImagesByPlaceholderId
+        )
 
-        // 10. Generate final XML output
         return xmlGenerator.buildXml(
             boxes = sortedBoxes,
             annotations = finalAnnotations,
@@ -74,26 +82,6 @@ class YoloToXmlConverter(
         )
     }
 
-    /** Groups switches by vertical center bands before collapsing duplicate text-input detections. */
-    private fun extractUiCandidates(detections: List<DetectionResult>): List<DetectionResult> {
-        val candidates = detections
-            .filterNot { it.isInvalidWidgetTag() }
-            .filter { (it.isYolo || it.label == "text") && it.label != "widget_tag" }
-            .filter { it.isCanvasRenderable() }
-            .filterNot { MetadataDetector.isMetadataDetection(it.label, it.text) }
-            .distinctBy {
-                if (it.label.startsWith("switch")) {
-                    // Deduplicate switches by grouping them within a {SWITCH_VERTICAL_BAND_SIZE}px vertical band
-                    "${((it.boundingBox.top + it.boundingBox.bottom) / 2f).toInt() / SWITCH_VERTICAL_BAND_SIZE}"
-                } else {
-                    // Exact coordinate deduplication for other widgets
-                    "${it.label}:${it.boundingBox.left}:${it.boundingBox.top}:${it.boundingBox.right}:${it.boundingBox.bottom}"
-                }
-            }
-
-        return TextInputDetectionCollapser.collapse(candidates)
-    }
-
     private fun scaleDetections(
         candidates: List<DetectionResult>,
         sourceWidth: Int,
@@ -101,241 +89,18 @@ class YoloToXmlConverter(
         targetWidth: Int,
         targetHeight: Int
     ): List<ScaledBox> {
-        return candidates.map {
-            DetectionScaler.scale(it, sourceWidth, sourceHeight, targetWidth, targetHeight)
+        return candidates.map { candidate ->
+            DetectionScaler.scale(
+                candidate,
+                sourceWidth,
+                sourceHeight,
+                targetWidth,
+                targetHeight
+            )
         }
-    }
-
-    private fun normalizeCompoundButtonsByNearestTag(
-        boxes: List<ScaledBox>,
-        canvasTags: List<ScaledBox>
-    ): List<ScaledBox> {
-        val compoundTags = canvasTags.mapNotNull { tagBox ->
-            val normalizedTag = WidgetTagParser.normalizeTagText(tagBox.text)
-
-            when {
-                normalizedTag.startsWith(CHECKBOX_TAG_PREFIX) -> tagBox to CompoundGroupType.CHECKBOX
-                normalizedTag.startsWith(RADIO_TAG_PREFIX) -> tagBox to CompoundGroupType.RADIO
-                else -> null
-            }
-        }
-
-        if (compoundTags.isEmpty()) {
-            return collapseOverlappingCompoundButtons(boxes)
-        }
-
-        val normalizedBoxes = boxes.map { box ->
-            if (!box.isCompoundButton()) return@map box
-
-            val nearestTag = compoundTags.minByOrNull { (tagBox, _) ->
-                val verticalDistance = abs(tagBox.centerY - box.centerY)
-                val horizontalDistance = abs(tagBox.centerX - box.centerX)
-
-                (verticalDistance * COMPOUND_TAG_VERTICAL_DISTANCE_WEIGHT) + horizontalDistance
-            } ?: return@map box
-
-            val tagBox = nearestTag.first
-            val groupType = nearestTag.second
-            val verticalDistance = abs(tagBox.centerY - box.centerY)
-
-            if (verticalDistance > MAX_COMPOUND_TAG_VERTICAL_DISTANCE) {
-                box
-            } else {
-                box.withCompoundGroupType(groupType)
-            }
-        }
-
-        return collapseOverlappingCompoundButtons(normalizedBoxes)
-    }
-
-    private fun collapseOverlappingCompoundButtons(boxes: List<ScaledBox>): List<ScaledBox> {
-        val result = mutableListOf<ScaledBox>()
-
-        for (box in boxes.sortedWith(compareBy({ it.y }, { it.x }))) {
-            if (!box.isCompoundButton()) {
-                result.add(box)
-                continue
-            }
-
-            val duplicateIndex = result.indexOfFirst { existing ->
-                existing.isCompoundButton() &&
-                    existing.label == box.label &&
-                    existing.overlapsCompoundDuplicate(box)
-            }
-
-            if (duplicateIndex < 0) {
-                result.add(box)
-                continue
-            }
-
-            val existing = result[duplicateIndex]
-            if (box.area > existing.area) {
-                result[duplicateIndex] = box
-            }
-        }
-
-        return result
-    }
-
-    private fun ScaledBox.withCompoundGroupType(groupType: CompoundGroupType): ScaledBox {
-        return when (groupType) {
-            CompoundGroupType.CHECKBOX -> copy(label = asCheckboxLabel())
-            CompoundGroupType.RADIO -> copy(label = asRadioButtonLabel())
-        }
-    }
-
-    private fun ScaledBox.isCompoundButton(): Boolean {
-        return label.startsWith(RADIO_BUTTON_LABEL_PREFIX) ||
-            label.startsWith(CHECKBOX_LABEL_PREFIX)
-    }
-
-    private fun ScaledBox.asCheckboxLabel(): String {
-        return if (label.endsWith(CHECKED_LABEL_SUFFIX)) {
-            CHECKBOX_CHECKED_LABEL
-        } else {
-            CHECKBOX_UNCHECKED_LABEL
-        }
-    }
-
-    private fun ScaledBox.asRadioButtonLabel(): String {
-        return if (label.endsWith(CHECKED_LABEL_SUFFIX)) {
-            RADIO_BUTTON_CHECKED_LABEL
-        } else {
-            RADIO_BUTTON_UNCHECKED_LABEL
-        }
-    }
-
-    private fun ScaledBox.overlapsCompoundDuplicate(other: ScaledBox): Boolean {
-        val intersectionWidth = minOf(x + w, other.x + other.w) - maxOf(x, other.x)
-        val intersectionHeight = minOf(y + h, other.y + other.h) - maxOf(y, other.y)
-
-        if (intersectionWidth <= 0 || intersectionHeight <= 0) return false
-
-        val intersectionArea = intersectionWidth * intersectionHeight
-        val smallerArea = minOf(area, other.area).coerceAtLeast(1)
-
-        return intersectionArea.toFloat() / smallerArea.toFloat() >= COMPOUND_DUPLICATE_OVERLAP_THRESHOLD
-    }
-
-    private fun associateTextToWidgets(scaledBoxes: List<ScaledBox>): List<ScaledBox> {
-        val parents = scaledBoxes.filter { it.label != "text" }
-        val initialTexts = scaledBoxes.filter { it.label == "text" && !annotationMatcher.isTagLikeText(it.text) }
-
-        val textAssignedBoxes = TextAssociator.assignTextToParents(parents, initialTexts, scaledBoxes)
-        val remainingTexts = textAssignedBoxes.filter { it.label == "text" && !annotationMatcher.isTagLikeText(it.text) }
-
-        return TextAssociator.assignNearbyTextToWidgets(textAssignedBoxes, remainingTexts)
-    }
-
-    private fun finalizeUiElements(boxes: List<ScaledBox>): List<ScaledBox> {
-        return boxes.filter { box ->
-            // Keep the widget if it's not pure text, or if it is text but not recognized as a tag.
-            val keep = (box.label != "text" || !annotationMatcher.isTagLikeText(box.text)) &&
-                !MetadataDetector.isMetadataDetection(box.label, box.text)
-            keep
-        }
-    }
-
-    private fun extractCanvasTags(
-        detections: List<DetectionResult>,
-        sourceWidth: Int,
-        sourceHeight: Int,
-        targetWidth: Int,
-        targetHeight: Int
-    ): List<ScaledBox> {
-        val widgetTags = detections.filter {
-            (it.region == null || it.region == SketchRegion.CANVAS) &&
-                ((it.label == "widget_tag" && WidgetTagParser.extractTag(it.text) != null) ||
-                    (!it.isYolo && annotationMatcher.isTag(it.text)))
-        }
-
-        return widgetTags.map { detection ->
-            DetectionScaler.scale(detection, sourceWidth, sourceHeight, targetWidth, targetHeight)
-        }
-    }
-
-    private fun filterLikelyDuplicateImagePlaceholders(
-        uiElements: List<ScaledBox>,
-        annotations: Map<ScaledBox, String>
-    ): List<ScaledBox> {
-        val annotatedImages = uiElements
-            .filter { it.isImagePlaceholder() && annotations.containsKey(it) }
-
-        if (annotatedImages.isEmpty()) return uiElements
-
-        return uiElements.filterNot { box ->
-            box.isImagePlaceholder() &&
-                !annotations.containsKey(box) &&
-                annotatedImages.any { annotated -> box.isLikelyDuplicateOf(annotated) }
-        }
-    }
-
-    private fun ScaledBox.isImagePlaceholder(): Boolean {
-        return label.startsWith("image_placeholder")
-    }
-
-    /** Compares area, horizontal overlap, and vertical gap to identify duplicate image placeholders. */
-    private fun ScaledBox.isLikelyDuplicateOf(annotated: ScaledBox): Boolean {
-        val maxDuplicateArea = annotated.area * IMAGE_PLACEHOLDER_MAX_DUPLICATE_AREA_RATIO
-        val verticalGap = when {
-            y >= annotated.y + annotated.h -> y - (annotated.y + annotated.h)
-            annotated.y >= y + h -> annotated.y - (y + h)
-            else -> 0
-        }
-        val hasHorizontalOverlap = x < annotated.x + annotated.w && x + w > annotated.x
-
-        return area < maxDuplicateArea &&
-            hasHorizontalOverlap &&
-            verticalGap <= annotated.h / 2
-    }
-
-    /** Calculates the scaled box area in target DP units. */
-    private val ScaledBox.area: Int
-        get() = w * h
-
-    private fun DetectionResult.isInvalidWidgetTag(): Boolean {
-        return label == "widget_tag" && WidgetTagParser.extractTag(text) == null
-    }
-
-    private fun DetectionResult.isCanvasRenderable(): Boolean {
-        return when (region) {
-            null, SketchRegion.CANVAS -> true
-            SketchRegion.CROSS_BOUNDARY -> label == "text" &&
-                text.isNotBlank() &&
-                !MetadataDetector.isCanvasMetadata(text) &&
-                !WidgetTagParser.isTagSequence(text)
-
-            SketchRegion.LEFT_METADATA,
-            SketchRegion.RIGHT_METADATA -> false
-        }
-    }
-
-    private enum class CompoundGroupType {
-        RADIO,
-        CHECKBOX
     }
 
     companion object {
-        private const val SWITCH_VERTICAL_BAND_SIZE = 50
-
-        private const val CHECKBOX_TAG_PREFIX = "C-"
-        private const val RADIO_TAG_PREFIX = "R-"
-
-        private const val CHECKBOX_LABEL_PREFIX = "checkbox"
-        private const val RADIO_BUTTON_LABEL_PREFIX = "radio_button"
-        private const val CHECKED_LABEL_SUFFIX = "_checked"
-
-        private const val CHECKBOX_CHECKED_LABEL = "checkbox_checked"
-        private const val CHECKBOX_UNCHECKED_LABEL = "checkbox_unchecked"
-        private const val RADIO_BUTTON_CHECKED_LABEL = "radio_button_checked"
-        private const val RADIO_BUTTON_UNCHECKED_LABEL = "radio_button_unchecked"
-
-        private const val COMPOUND_TAG_VERTICAL_DISTANCE_WEIGHT = 2
-        private const val MAX_COMPOUND_TAG_VERTICAL_DISTANCE = 100
-        private const val COMPOUND_DUPLICATE_OVERLAP_THRESHOLD = 0.80f
-
-        private const val IMAGE_PLACEHOLDER_MAX_DUPLICATE_AREA_RATIO = 0.35
-
         fun generateXmlLayout(
             detections: List<DetectionResult>,
             annotations: Map<String, String>,

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/YoloToXmlConverter.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/YoloToXmlConverter.kt
@@ -7,6 +7,7 @@ import org.appdevforall.codeonthego.computervision.domain.xml.AndroidXmlGenerato
 import org.appdevforall.codeonthego.computervision.utils.MetadataDetector
 import org.appdevforall.codeonthego.computervision.utils.buildPlaceholderOverrides
 import kotlin.comparisons.compareBy
+import kotlin.math.abs
 
 class YoloToXmlConverter(
     private val annotationMatcher: WidgetAnnotationMatcher,
@@ -26,28 +27,44 @@ class YoloToXmlConverter(
         val uiCandidates = extractUiCandidates(detections)
 
         // 2. Scale detections to target DP dimensions
-        val scaledBoxes = scaleDetections(uiCandidates, sourceImageWidth, sourceImageHeight, targetDpWidth, targetDpHeight)
+        val scaledBoxes = scaleDetections(
+            uiCandidates,
+            sourceImageWidth,
+            sourceImageHeight,
+            targetDpWidth,
+            targetDpHeight
+        )
 
-        // 3. Associate isolated text detections to their respective UI widgets
-        val associatedBoxes = associateTextToWidgets(scaledBoxes)
+        // 3. Extract and scale reference tags before text association.
+        // This allows checkbox/radio normalization to use C-* and R-* context.
+        val canvasTags = extractCanvasTags(
+            detections,
+            sourceImageWidth,
+            sourceImageHeight,
+            targetDpWidth,
+            targetDpHeight
+        )
 
-        // 4. Clean up and finalize the UI elements list
+        // 4. Normalize noisy checkbox/radio detections before text association and layout grouping
+        val normalizedBoxes = normalizeCompoundButtonsByNearestTag(scaledBoxes, canvasTags)
+
+        // 5. Associate isolated text detections to their respective UI widgets
+        val associatedBoxes = associateTextToWidgets(normalizedBoxes)
+
+        // 6. Clean up and finalize the UI elements list
         val uiElements = finalizeUiElements(associatedBoxes)
 
-        // 5. Extract and scale reference tags (e.g., T-1, B-1) from the canvas
-        val canvasTags = extractCanvasTags(detections, sourceImageWidth, sourceImageHeight, targetDpWidth, targetDpHeight)
-
-        // 6. Match margin annotations with the extracted UI elements
+        // 7. Match margin annotations with the extracted UI elements
         val finalAnnotations = annotationMatcher.matchAnnotationsToElements(canvasTags, uiElements, annotations)
         val filteredUiElements = filterLikelyDuplicateImagePlaceholders(uiElements, finalAnnotations)
 
-        // 7. Sort boxes top-to-bottom, left-to-right for sequential XML rendering
+        // 8. Sort boxes top-to-bottom, left-to-right for sequential XML rendering
         val sortedBoxes = filteredUiElements.sortedWith(compareBy({ it.y }, { it.x }))
 
-        // 8. Prepare local drawable resources overrides for image placeholders
+        // 9. Prepare local drawable resources overrides for image placeholders
         val selectedImageOverrides = filteredUiElements.buildPlaceholderOverrides(selectedImagesByPlaceholderId)
 
-        // 9. Generate final XML output
+        // 10. Generate final XML output
         return xmlGenerator.buildXml(
             boxes = sortedBoxes,
             annotations = finalAnnotations,
@@ -66,8 +83,8 @@ class YoloToXmlConverter(
             .filterNot { MetadataDetector.isMetadataDetection(it.label, it.text) }
             .distinctBy {
                 if (it.label.startsWith("switch")) {
-                    // Deduplicate switches by grouping them within a 50px vertical band
-                    "${((it.boundingBox.top + it.boundingBox.bottom) / 2f).toInt() / 50}"
+                    // Deduplicate switches by grouping them within a {SWITCH_VERTICAL_BAND_SIZE}px vertical band
+                    "${((it.boundingBox.top + it.boundingBox.bottom) / 2f).toInt() / SWITCH_VERTICAL_BAND_SIZE}"
                 } else {
                     // Exact coordinate deduplication for other widgets
                     "${it.label}:${it.boundingBox.left}:${it.boundingBox.top}:${it.boundingBox.right}:${it.boundingBox.bottom}"
@@ -84,9 +101,120 @@ class YoloToXmlConverter(
         targetWidth: Int,
         targetHeight: Int
     ): List<ScaledBox> {
-        return candidates.map { 
+        return candidates.map {
             DetectionScaler.scale(it, sourceWidth, sourceHeight, targetWidth, targetHeight)
         }
+    }
+
+    private fun normalizeCompoundButtonsByNearestTag(
+        boxes: List<ScaledBox>,
+        canvasTags: List<ScaledBox>
+    ): List<ScaledBox> {
+        val compoundTags = canvasTags.mapNotNull { tagBox ->
+            val normalizedTag = WidgetTagParser.normalizeTagText(tagBox.text)
+
+            when {
+                normalizedTag.startsWith(CHECKBOX_TAG_PREFIX) -> tagBox to CompoundGroupType.CHECKBOX
+                normalizedTag.startsWith(RADIO_TAG_PREFIX) -> tagBox to CompoundGroupType.RADIO
+                else -> null
+            }
+        }
+
+        if (compoundTags.isEmpty()) {
+            return collapseOverlappingCompoundButtons(boxes)
+        }
+
+        val normalizedBoxes = boxes.map { box ->
+            if (!box.isCompoundButton()) return@map box
+
+            val nearestTag = compoundTags.minByOrNull { (tagBox, _) ->
+                val verticalDistance = abs(tagBox.centerY - box.centerY)
+                val horizontalDistance = abs(tagBox.centerX - box.centerX)
+
+                (verticalDistance * COMPOUND_TAG_VERTICAL_DISTANCE_WEIGHT) + horizontalDistance
+            } ?: return@map box
+
+            val tagBox = nearestTag.first
+            val groupType = nearestTag.second
+            val verticalDistance = abs(tagBox.centerY - box.centerY)
+
+            if (verticalDistance > MAX_COMPOUND_TAG_VERTICAL_DISTANCE) {
+                box
+            } else {
+                box.withCompoundGroupType(groupType)
+            }
+        }
+
+        return collapseOverlappingCompoundButtons(normalizedBoxes)
+    }
+
+    private fun collapseOverlappingCompoundButtons(boxes: List<ScaledBox>): List<ScaledBox> {
+        val result = mutableListOf<ScaledBox>()
+
+        for (box in boxes.sortedWith(compareBy({ it.y }, { it.x }))) {
+            if (!box.isCompoundButton()) {
+                result.add(box)
+                continue
+            }
+
+            val duplicateIndex = result.indexOfFirst { existing ->
+                existing.isCompoundButton() &&
+                    existing.label == box.label &&
+                    existing.overlapsCompoundDuplicate(box)
+            }
+
+            if (duplicateIndex < 0) {
+                result.add(box)
+                continue
+            }
+
+            val existing = result[duplicateIndex]
+            if (box.area > existing.area) {
+                result[duplicateIndex] = box
+            }
+        }
+
+        return result
+    }
+
+    private fun ScaledBox.withCompoundGroupType(groupType: CompoundGroupType): ScaledBox {
+        return when (groupType) {
+            CompoundGroupType.CHECKBOX -> copy(label = asCheckboxLabel())
+            CompoundGroupType.RADIO -> copy(label = asRadioButtonLabel())
+        }
+    }
+
+    private fun ScaledBox.isCompoundButton(): Boolean {
+        return label.startsWith(RADIO_BUTTON_LABEL_PREFIX) ||
+            label.startsWith(CHECKBOX_LABEL_PREFIX)
+    }
+
+    private fun ScaledBox.asCheckboxLabel(): String {
+        return if (label.endsWith(CHECKED_LABEL_SUFFIX)) {
+            CHECKBOX_CHECKED_LABEL
+        } else {
+            CHECKBOX_UNCHECKED_LABEL
+        }
+    }
+
+    private fun ScaledBox.asRadioButtonLabel(): String {
+        return if (label.endsWith(CHECKED_LABEL_SUFFIX)) {
+            RADIO_BUTTON_CHECKED_LABEL
+        } else {
+            RADIO_BUTTON_UNCHECKED_LABEL
+        }
+    }
+
+    private fun ScaledBox.overlapsCompoundDuplicate(other: ScaledBox): Boolean {
+        val intersectionWidth = minOf(x + w, other.x + other.w) - maxOf(x, other.x)
+        val intersectionHeight = minOf(y + h, other.y + other.h) - maxOf(y, other.y)
+
+        if (intersectionWidth <= 0 || intersectionHeight <= 0) return false
+
+        val intersectionArea = intersectionWidth * intersectionHeight
+        val smallerArea = minOf(area, other.area).coerceAtLeast(1)
+
+        return intersectionArea.toFloat() / smallerArea.toFloat() >= COMPOUND_DUPLICATE_OVERLAP_THRESHOLD
     }
 
     private fun associateTextToWidgets(scaledBoxes: List<ScaledBox>): List<ScaledBox> {
@@ -115,11 +243,12 @@ class YoloToXmlConverter(
         targetWidth: Int,
         targetHeight: Int
     ): List<ScaledBox> {
-        val widgetTags = detections.filter { 
+        val widgetTags = detections.filter {
             (it.region == null || it.region == SketchRegion.CANVAS) &&
                 ((it.label == "widget_tag" && WidgetTagParser.extractTag(it.text) != null) ||
                     (!it.isYolo && annotationMatcher.isTag(it.text)))
         }
+
         return widgetTags.map { detection ->
             DetectionScaler.scale(detection, sourceWidth, sourceHeight, targetWidth, targetHeight)
         }
@@ -131,6 +260,7 @@ class YoloToXmlConverter(
     ): List<ScaledBox> {
         val annotatedImages = uiElements
             .filter { it.isImagePlaceholder() && annotations.containsKey(it) }
+
         if (annotatedImages.isEmpty()) return uiElements
 
         return uiElements.filterNot { box ->
@@ -146,13 +276,14 @@ class YoloToXmlConverter(
 
     /** Compares area, horizontal overlap, and vertical gap to identify duplicate image placeholders. */
     private fun ScaledBox.isLikelyDuplicateOf(annotated: ScaledBox): Boolean {
-        val maxDuplicateArea = annotated.area * 0.35
+        val maxDuplicateArea = annotated.area * IMAGE_PLACEHOLDER_MAX_DUPLICATE_AREA_RATIO
         val verticalGap = when {
             y >= annotated.y + annotated.h -> y - (annotated.y + annotated.h)
             annotated.y >= y + h -> annotated.y - (y + h)
             else -> 0
         }
         val hasHorizontalOverlap = x < annotated.x + annotated.w && x + w > annotated.x
+
         return area < maxDuplicateArea &&
             hasHorizontalOverlap &&
             verticalGap <= annotated.h / 2
@@ -173,11 +304,38 @@ class YoloToXmlConverter(
                 text.isNotBlank() &&
                 !MetadataDetector.isCanvasMetadata(text) &&
                 !WidgetTagParser.isTagSequence(text)
-            SketchRegion.LEFT_METADATA, SketchRegion.RIGHT_METADATA -> false
+
+            SketchRegion.LEFT_METADATA,
+            SketchRegion.RIGHT_METADATA -> false
         }
     }
 
+    private enum class CompoundGroupType {
+        RADIO,
+        CHECKBOX
+    }
+
     companion object {
+        private const val SWITCH_VERTICAL_BAND_SIZE = 50
+
+        private const val CHECKBOX_TAG_PREFIX = "C-"
+        private const val RADIO_TAG_PREFIX = "R-"
+
+        private const val CHECKBOX_LABEL_PREFIX = "checkbox"
+        private const val RADIO_BUTTON_LABEL_PREFIX = "radio_button"
+        private const val CHECKED_LABEL_SUFFIX = "_checked"
+
+        private const val CHECKBOX_CHECKED_LABEL = "checkbox_checked"
+        private const val CHECKBOX_UNCHECKED_LABEL = "checkbox_unchecked"
+        private const val RADIO_BUTTON_CHECKED_LABEL = "radio_button_checked"
+        private const val RADIO_BUTTON_UNCHECKED_LABEL = "radio_button_unchecked"
+
+        private const val COMPOUND_TAG_VERTICAL_DISTANCE_WEIGHT = 2
+        private const val MAX_COMPOUND_TAG_VERTICAL_DISTANCE = 100
+        private const val COMPOUND_DUPLICATE_OVERLAP_THRESHOLD = 0.80f
+
+        private const val IMAGE_PLACEHOLDER_MAX_DUPLICATE_AREA_RATIO = 0.35
+
         fun generateXmlLayout(
             detections: List<DetectionResult>,
             annotations: Map<String, String>,

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/converter/CanvasTagExtractor.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/converter/CanvasTagExtractor.kt
@@ -1,0 +1,44 @@
+package org.appdevforall.codeonthego.computervision.domain.converter
+
+import org.appdevforall.codeonthego.computervision.domain.DetectionScaler
+import org.appdevforall.codeonthego.computervision.domain.WidgetAnnotationMatcher
+import org.appdevforall.codeonthego.computervision.domain.WidgetTagParser
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionLabels
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
+import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+import org.appdevforall.codeonthego.computervision.domain.model.SketchRegion
+
+class CanvasTagExtractor(
+    private val annotationMatcher: WidgetAnnotationMatcher
+) {
+
+    fun extract(
+        detections: List<DetectionResult>,
+        sourceWidth: Int,
+        sourceHeight: Int,
+        targetWidth: Int,
+        targetHeight: Int
+    ): List<ScaledBox> {
+        return detections
+            .filter { it.isCanvasTag() }
+            .map { detection ->
+                DetectionScaler.scale(
+                    detection,
+                    sourceWidth,
+                    sourceHeight,
+                    targetWidth,
+                    targetHeight
+                )
+            }
+    }
+
+    private fun DetectionResult.isCanvasTag(): Boolean {
+        val isCanvasRegion = region == null || region == SketchRegion.CANVAS
+        if (!isCanvasRegion) return false
+
+        val isYoloWidgetTag = label == DetectionLabels.WIDGET_TAG && WidgetTagParser.extractTag(text) != null
+        val isOcrTag = !isYolo && annotationMatcher.isTag(text)
+
+        return isYoloWidgetTag || isOcrTag
+    }
+}

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/converter/CompoundButtonNormalizer.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/converter/CompoundButtonNormalizer.kt
@@ -1,0 +1,129 @@
+package org.appdevforall.codeonthego.computervision.domain.converter
+
+import org.appdevforall.codeonthego.computervision.domain.WidgetTagParser
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionLabels
+import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+import org.appdevforall.codeonthego.computervision.domain.widgettag.WidgetTagPrefixes
+import kotlin.math.abs
+
+class CompoundButtonNormalizer {
+
+    fun normalizeByNearestTag(
+        boxes: List<ScaledBox>,
+        canvasTags: List<ScaledBox>
+    ): List<ScaledBox> {
+        val compoundTags = canvasTags.mapNotNull { tagBox ->
+            val normalizedTag = WidgetTagParser.normalizeTagText(tagBox.text)
+
+            when {
+                normalizedTag.startsWith(WidgetTagPrefixes.CHECKBOX) -> tagBox to CompoundGroupType.CHECKBOX
+                normalizedTag.startsWith(WidgetTagPrefixes.RADIO) -> tagBox to CompoundGroupType.RADIO
+                else -> null
+            }
+        }
+
+        if (compoundTags.isEmpty()) {
+            return collapseOverlappingCompoundButtons(boxes)
+        }
+
+        val normalizedBoxes = boxes.map { box ->
+            if (!DetectionLabels.isCompoundButton(box.label)) return@map box
+
+            val nearestTag = compoundTags.minByOrNull { (tagBox, _) ->
+                val verticalDistance = abs(tagBox.centerY - box.centerY)
+                val horizontalDistance = abs(tagBox.centerX - box.centerX)
+
+                (verticalDistance * VERTICAL_DISTANCE_WEIGHT) + horizontalDistance
+            } ?: return@map box
+
+            val tagBox = nearestTag.first
+            val groupType = nearestTag.second
+            val verticalDistance = abs(tagBox.centerY - box.centerY)
+
+            if (verticalDistance > MAX_COMPOUND_TAG_VERTICAL_DISTANCE) {
+                box
+            } else {
+                box.withCompoundGroupType(groupType)
+            }
+        }
+
+        return collapseOverlappingCompoundButtons(normalizedBoxes)
+    }
+
+    private fun collapseOverlappingCompoundButtons(boxes: List<ScaledBox>): List<ScaledBox> {
+        val result = mutableListOf<ScaledBox>()
+
+        for (box in boxes.sortedWith(compareBy({ it.y }, { it.x }))) {
+            if (!DetectionLabels.isCompoundButton(box.label)) {
+                result.add(box)
+                continue
+            }
+
+            val duplicateIndex = result.indexOfFirst { existing ->
+                DetectionLabels.isCompoundButton(existing.label) &&
+                    existing.label == box.label &&
+                    existing.overlapsCompoundDuplicate(box)
+            }
+
+            if (duplicateIndex < 0) {
+                result.add(box)
+                continue
+            }
+
+            val existing = result[duplicateIndex]
+            if (box.area() > existing.area()) {
+                result[duplicateIndex] = box
+            }
+        }
+
+        return result
+    }
+
+    private fun ScaledBox.withCompoundGroupType(groupType: CompoundGroupType): ScaledBox {
+        return when (groupType) {
+            CompoundGroupType.CHECKBOX -> copy(label = asCheckboxLabel())
+            CompoundGroupType.RADIO -> copy(label = asRadioButtonLabel())
+        }
+    }
+
+    private fun ScaledBox.asCheckboxLabel(): String {
+        if (DetectionLabels.isChecked(label)) {
+            return DetectionLabels.CHECKBOX_CHECKED
+        }
+        return DetectionLabels.CHECKBOX_UNCHECKED
+    }
+
+    private fun ScaledBox.asRadioButtonLabel(): String {
+        if (DetectionLabels.isChecked(label)) {
+            return DetectionLabels.RADIO_BUTTON_CHECKED
+        }
+        return DetectionLabels.RADIO_BUTTON_UNCHECKED
+    }
+
+    private fun ScaledBox.overlapsCompoundDuplicate(other: ScaledBox): Boolean {
+        val intersectionWidth = minOf(x + w, other.x + other.w) - maxOf(x, other.x)
+        val intersectionHeight = minOf(y + h, other.y + other.h) - maxOf(y, other.y)
+
+        if (intersectionWidth <= 0 || intersectionHeight <= 0) return false
+
+        val intersectionArea = intersectionWidth * intersectionHeight
+        val smallerArea = minOf(area(), other.area()).coerceAtLeast(1)
+
+        return intersectionArea.toFloat() / smallerArea.toFloat() >= COMPOUND_DUPLICATE_OVERLAP_THRESHOLD
+    }
+
+    private fun ScaledBox.area(): Int {
+        return w * h
+    }
+
+    private enum class CompoundGroupType {
+        RADIO,
+        CHECKBOX
+    }
+
+    private companion object {
+        const val VERTICAL_DISTANCE_WEIGHT = 2
+        const val MAX_COMPOUND_TAG_VERTICAL_DISTANCE = 100
+        const val COMPOUND_DUPLICATE_OVERLAP_THRESHOLD = 0.80f
+    }
+}

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/converter/ImagePlaceholderDuplicateFilter.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/converter/ImagePlaceholderDuplicateFilter.kt
@@ -1,0 +1,57 @@
+package org.appdevforall.codeonthego.computervision.domain.converter
+
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionLabels
+import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+
+class ImagePlaceholderDuplicateFilter {
+
+    fun filter(
+        uiElements: List<ScaledBox>,
+        annotations: Map<ScaledBox, String>
+    ): List<ScaledBox> {
+        val annotatedImages = uiElements
+            .filter { it.isImagePlaceholder() && annotations.containsKey(it) }
+
+        if (annotatedImages.isEmpty()) return uiElements
+
+        return uiElements.filterNot { box ->
+            box.isImagePlaceholder() &&
+                !annotations.containsKey(box) &&
+                annotatedImages.any { annotated -> box.isLikelyDuplicateOf(annotated) }
+        }
+    }
+
+    private fun ScaledBox.isImagePlaceholder(): Boolean = DetectionLabels.isImagePlaceholder(label)
+
+    private fun ScaledBox.isLikelyDuplicateOf(annotated: ScaledBox): Boolean {
+        val maxDuplicateArea = annotated.area() * MAX_DUPLICATE_AREA_RATIO
+        val verticalGap = verticalGapFrom(annotated)
+        val hasHorizontalOverlap = x < annotated.x + annotated.w && x + w > annotated.x
+
+        return area() < maxDuplicateArea &&
+            hasHorizontalOverlap &&
+            verticalGap <= annotated.h / 2
+    }
+
+    private fun ScaledBox.verticalGapFrom(other: ScaledBox): Int {
+        val thisBoxBottom = y + h
+        val otherBoxBottom = other.y + other.h
+
+        val distanceFromOtherBottomToThisTop = y - otherBoxBottom
+        val distanceFromThisBottomToOtherTop = other.y - thisBoxBottom
+
+        return when {
+            distanceFromOtherBottomToThisTop >= 0 -> distanceFromOtherBottomToThisTop
+            distanceFromThisBottomToOtherTop >= 0 -> distanceFromThisBottomToOtherTop
+            else -> 0
+        }
+    }
+
+    private fun ScaledBox.area(): Int {
+        return w * h
+    }
+
+    private companion object {
+        const val MAX_DUPLICATE_AREA_RATIO = 0.35
+    }
+}

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/converter/TextAssociationProcessor.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/converter/TextAssociationProcessor.kt
@@ -1,0 +1,48 @@
+package org.appdevforall.codeonthego.computervision.domain.converter
+
+import org.appdevforall.codeonthego.computervision.domain.TextAssociator
+import org.appdevforall.codeonthego.computervision.domain.WidgetAnnotationMatcher
+import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+import org.appdevforall.codeonthego.computervision.utils.MetadataDetector
+
+class TextAssociationProcessor(
+    private val annotationMatcher: WidgetAnnotationMatcher
+) {
+
+    fun associateText(boxes: List<ScaledBox>): List<ScaledBox> {
+        val parents = boxes.filterNot { it.isText() }
+        val initialTexts = boxes.filter { it.isAssociableText() }
+
+        val textAssignedBoxes = TextAssociator.assignTextToParents(
+            parents = parents,
+            texts = initialTexts,
+            allBoxes = boxes
+        )
+
+        val remainingTexts = textAssignedBoxes.filter { it.isAssociableText() }
+
+        return TextAssociator.assignNearbyTextToWidgets(textAssignedBoxes, remainingTexts)
+    }
+
+    fun finalizeUiElements(boxes: List<ScaledBox>): List<ScaledBox> {
+        return boxes.filter { box ->
+            val isRenderableText = box.isText() && !annotationMatcher.isTagLikeText(box.text)
+            val isWidget = !box.isText()
+
+            (isWidget || isRenderableText) &&
+                !MetadataDetector.isMetadataDetection(box.label, box.text)
+        }
+    }
+
+    private fun ScaledBox.isAssociableText(): Boolean {
+        return isText() && !annotationMatcher.isTagLikeText(text)
+    }
+
+    private fun ScaledBox.isText(): Boolean {
+        return label == TEXT_LABEL
+    }
+
+    private companion object {
+        const val TEXT_LABEL = "text"
+    }
+}

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/converter/UiCandidateExtractor.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/converter/UiCandidateExtractor.kt
@@ -1,0 +1,53 @@
+package org.appdevforall.codeonthego.computervision.domain.converter
+
+import org.appdevforall.codeonthego.computervision.domain.TextInputDetectionCollapser
+import org.appdevforall.codeonthego.computervision.domain.WidgetTagParser
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionLabels
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
+import org.appdevforall.codeonthego.computervision.domain.model.SketchRegion
+import org.appdevforall.codeonthego.computervision.utils.MetadataDetector
+
+class UiCandidateExtractor {
+
+    fun extract(detections: List<DetectionResult>): List<DetectionResult> {
+        val candidates = detections
+            .filterNot { it.isInvalidWidgetTag() }
+            .filter { (it.isYolo || it.label == DetectionLabels.TEXT) && it.label != DetectionLabels.WIDGET_TAG }
+            .filter { it.isCanvasRenderable() }
+            .filterNot { MetadataDetector.isMetadataDetection(it.label, it.text) }
+            .distinctBy { it.deduplicationKey() }
+
+        return TextInputDetectionCollapser.collapse(candidates)
+    }
+
+    private fun DetectionResult.deduplicationKey(): String {
+        if (label.startsWith(DetectionLabels.SWITCH_PREFIX)) {
+            val centerY = ((boundingBox.top + boundingBox.bottom) / 2f).toInt()
+            return "${DetectionLabels.SWITCH_PREFIX}_${centerY / SWITCH_VERTICAL_BAND_SIZE}"
+        }
+
+        return "${label}:${boundingBox.left}:${boundingBox.top}:${boundingBox.right}:${boundingBox.bottom}"
+    }
+
+    private fun DetectionResult.isInvalidWidgetTag(): Boolean {
+        return label == DetectionLabels.WIDGET_TAG && WidgetTagParser.extractTag(text) == null
+    }
+
+    private fun DetectionResult.isCanvasRenderable(): Boolean {
+        return when (region) {
+            null, SketchRegion.CANVAS -> true
+
+            SketchRegion.CROSS_BOUNDARY -> label == DetectionLabels.TEXT &&
+                text.isNotBlank() &&
+                !MetadataDetector.isCanvasMetadata(text) &&
+                !WidgetTagParser.isTagSequence(text)
+
+            SketchRegion.LEFT_METADATA,
+            SketchRegion.RIGHT_METADATA -> false
+        }
+    }
+
+    private companion object {
+        const val SWITCH_VERTICAL_BAND_SIZE = 50
+    }
+}

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/model/DetectionLabels.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/model/DetectionLabels.kt
@@ -1,0 +1,79 @@
+package org.appdevforall.codeonthego.computervision.domain.model
+
+object DetectionLabels {
+    const val GENERIC_BOX = "generic_box"
+    const val DROPDOWN_SYMBOL = "dropdown_symbol"
+    const val IMAGE_PLACEHOLDER = "image_placeholder"
+    const val BUTTON = "button"
+
+    const val CHECKBOX_CHECKED = "checkbox_checked"
+    const val CHECKBOX_UNCHECKED = "checkbox_unchecked"
+
+    const val RADIO_BUTTON_CHECKED = "radio_button_checked"
+    const val RADIO_BUTTON_UNCHECKED = "radio_button_unchecked"
+
+    const val SLIDER = "slider"
+
+    const val SWITCH_OFF = "switch_off"
+    const val SWITCH_ON = "switch_on"
+
+    const val WIDGET_TAG = "widget_tag"
+    const val TEXT = "text"
+
+    const val DROPDOWN = "dropdown"
+    const val TEXT_ENTRY_BOX = "text_entry_box"
+
+    const val CHECKED_SUFFIX = "_checked"
+    const val ON_SUFFIX = "_on"
+
+    const val CHECKBOX_PREFIX = "checkbox"
+    const val RADIO_BUTTON_PREFIX = "radio_button"
+    const val SWITCH_PREFIX = "switch"
+    const val DROPDOWN_PREFIX = "dropdown"
+    const val SLIDER_PREFIX = "slider"
+    const val BUTTON_PREFIX = "button"
+    const val TEXT_ENTRY_BOX_PREFIX = "text_entry_box"
+    const val IMAGE_PLACEHOLDER_PREFIX = "image_placeholder"
+    const val ICON_PREFIX = "icon"
+
+    val checkboxLabels = setOf(
+        CHECKBOX_CHECKED,
+        CHECKBOX_UNCHECKED
+    )
+
+    val radioButtonLabels = setOf(
+        RADIO_BUTTON_CHECKED,
+        RADIO_BUTTON_UNCHECKED
+    )
+
+    val switchLabels = setOf(
+        SWITCH_ON,
+        SWITCH_OFF
+    )
+
+    val compoundButtonLabels = checkboxLabels + radioButtonLabels
+
+    fun isCheckbox(label: String): Boolean {
+        return label in checkboxLabels
+    }
+
+    fun isRadioButton(label: String): Boolean {
+        return label in radioButtonLabels
+    }
+
+    fun isSwitch(label: String): Boolean {
+        return label in switchLabels
+    }
+
+    fun isCompoundButton(label: String): Boolean {
+        return label in compoundButtonLabels
+    }
+
+    fun isChecked(label: String): Boolean {
+        return label.endsWith(CHECKED_SUFFIX) || label.endsWith(ON_SUFFIX)
+    }
+
+    fun isImagePlaceholder(label: String): Boolean {
+        return label.startsWith(IMAGE_PLACEHOLDER_PREFIX)
+    }
+}

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/model/WidgetTypes.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/model/WidgetTypes.kt
@@ -1,0 +1,12 @@
+package org.appdevforall.codeonthego.computervision.domain.model
+
+object WidgetTypes {
+    const val BUTTON = "button"
+    const val IMAGE_PLACEHOLDER = "image_placeholder"
+    const val DROPDOWN = "dropdown"
+    const val TEXT_ENTRY_BOX = "text_entry_box"
+    const val CHECKBOX = "checkbox"
+    const val RADIO = "radio"
+    const val SWITCH = "switch"
+    const val SLIDER = "slider"
+}

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/DimensionUnits.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/DimensionUnits.kt
@@ -1,0 +1,39 @@
+package org.appdevforall.codeonthego.computervision.domain.parser
+
+internal object DimensionUnits {
+    const val DP = "dp"
+    const val SP = "sp"
+    const val PX = "px"
+    const val IN = "in"
+    const val MM = "mm"
+    const val PT = "pt"
+
+    const val OCR_SP = "5p"
+    const val OCR_DUPLICATED_DP = "ddp"
+    const val OCR_DP_WITH_ZERO = "d0"
+    const val OCR_DP_WITH_O = "do"
+    const val OCR_DP_WITH_E = "de"
+
+    val supportedUnits = listOf(
+        DP,
+        SP,
+        PX,
+        IN,
+        MM,
+        PT
+    )
+
+    val noisySuffixes = listOf(
+        OCR_DUPLICATED_DP,
+        DP,
+        OCR_DP_WITH_ZERO,
+        OCR_DP_WITH_O,
+        OCR_DP_WITH_E,
+        SP,
+        OCR_SP,
+        PX,
+        IN,
+        MM,
+        PT
+    )
+}

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/cleaner/DimensionValueCleaners.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/cleaner/DimensionValueCleaners.kt
@@ -2,60 +2,26 @@ package org.appdevforall.codeonthego.computervision.domain.parser.cleaner
 
 import me.xdrop.fuzzywuzzy.FuzzySearch
 import org.appdevforall.codeonthego.computervision.domain.parser.AttributeRegexPatterns
+import org.appdevforall.codeonthego.computervision.domain.parser.DimensionUnits
 import org.appdevforall.codeonthego.computervision.domain.parser.DimensionValueSet
 import org.appdevforall.codeonthego.computervision.domain.parser.ValueCleaner
 
 internal object DimensionCleaner : ValueCleaner {
     private const val FUZZY_DIMENSION_THRESHOLD = 60
     private const val OCR_TRAILING_ZERO_MIN_VALUE = 1000L
-
-    private const val DP_UNIT = "dp"
-    private const val SP_UNIT = "sp"
-    private const val PX_UNIT = "px"
-    private const val IN_UNIT = "in"
-    private const val MM_UNIT = "mm"
-    private const val PT_UNIT = "pt"
-
-    private const val OCR_SP_UNIT = "5p"
-    private const val OCR_DUPLICATED_DP_UNIT = "ddp"
-    private const val OCR_DP_ZERO_UNIT = "d0"
-    private const val OCR_DP_LETTER_O_UNIT = "do"
-    private const val OCR_DP_LETTER_E_UNIT = "de"
-
     private const val OCR_DP_NOISE_D = 'd'
     private const val OCR_DP_NOISE_P = 'p'
-
-    private val noisyDimensionSuffixes = listOf(
-        OCR_DUPLICATED_DP_UNIT,
-        DP_UNIT,
-        OCR_DP_ZERO_UNIT,
-        OCR_DP_LETTER_O_UNIT,
-        OCR_DP_LETTER_E_UNIT,
-        SP_UNIT,
-        OCR_SP_UNIT,
-        PX_UNIT,
-        IN_UNIT,
-        MM_UNIT,
-        PT_UNIT
-    )
 
     /** Resolves dimensions using fuzzy scores and numeric OCR corrections. */
     override fun clean(rawValue: String): String {
         val trimmedValue = rawValue.trim().lowercase()
         val normalized = trimmedValue.replace(" ", "_")
 
-        if (DimensionValueSet.matchKeywords.any { it in normalized }) {
-            return DimensionValueSet.MATCH_PARENT
-        }
-
-        if (DimensionValueSet.wrapKeywords.any { it in normalized }) {
-            return DimensionValueSet.WRAP_CONTENT
-        }
+        if (DimensionValueSet.matchKeywords.any { it in normalized }) return DimensionValueSet.MATCH_PARENT
+        if (DimensionValueSet.wrapKeywords.any { it in normalized }) return DimensionValueSet.WRAP_CONTENT
 
         val fuzzyResult = FuzzySearch.extractOne(normalized, DimensionValueSet.values)
-        if (fuzzyResult.score >= FUZZY_DIMENSION_THRESHOLD) {
-            return fuzzyResult.string
-        }
+        if (fuzzyResult.score >= FUZZY_DIMENSION_THRESHOLD) return fuzzyResult.string
 
         val compactValue = trimmedValue
             .replace(" ", "")
@@ -75,18 +41,21 @@ internal object DimensionCleaner : ValueCleaner {
 
     private fun resolveDimensionUnit(value: String): String {
         return when {
-            value.endsWith(SP_UNIT) || value.endsWith(OCR_SP_UNIT) -> SP_UNIT
-            value.endsWith(PX_UNIT) -> PX_UNIT
-            value.endsWith(IN_UNIT) -> IN_UNIT
-            value.endsWith(MM_UNIT) -> MM_UNIT
-            value.endsWith(PT_UNIT) -> PT_UNIT
-            else -> DP_UNIT
+            value.endsWith(DimensionUnits.SP) ||
+                value.endsWith(DimensionUnits.OCR_SP) -> DimensionUnits.SP
+
+            value.endsWith(DimensionUnits.PX) -> DimensionUnits.PX
+            value.endsWith(DimensionUnits.IN) -> DimensionUnits.IN
+            value.endsWith(DimensionUnits.MM) -> DimensionUnits.MM
+            value.endsWith(DimensionUnits.PT) -> DimensionUnits.PT
+
+            else -> DimensionUnits.DP
         }
     }
 
     private fun removeDimensionUnitNoise(value: String): String {
-        val cleaned = noisyDimensionSuffixes
-            .firstOrNull { suffix -> value.endsWith(suffix) }
+        val cleaned = DimensionUnits.noisySuffixes
+            .firstOrNull { value.endsWith(it) }
             ?.let { suffix -> value.removeSuffix(suffix) }
             ?: value
 
@@ -97,10 +66,7 @@ internal object DimensionCleaner : ValueCleaner {
 
     /** Removes a likely OCR-added trailing zero from unusually large dimensions. */
     private fun removeOcrTrailingZero(num: String): String {
-        val numericValue = num.toLongOrNull() ?: 0L
-        val isOcrArtifact = num.endsWith("0") &&
-            numericValue >= OCR_TRAILING_ZERO_MIN_VALUE
-
+        val isOcrArtifact = num.endsWith("0") && (num.toLongOrNull() ?: 0L) >= OCR_TRAILING_ZERO_MIN_VALUE
         return if (isOcrArtifact) num.dropLast(1) else num
     }
 
@@ -115,20 +81,9 @@ internal object DimensionCleaner : ValueCleaner {
 }
 
 internal object SpDimensionCleaner : ValueCleaner {
-    private const val SP_UNIT = "sp"
-
     override fun clean(rawValue: String): String {
-        val normalized = rawValue
-            .lowercase()
-            .replace(" ", "")
-            .replace(AttributeRegexPatterns.SP_SUFFIX, "")
-
+        val normalized = rawValue.lowercase().replace(" ", "").replace(AttributeRegexPatterns.SP_SUFFIX, "")
         val numericPart = NumberCleaner.clean(normalized.replace("_", ""))
-
-        return if (numericPart != normalized) {
-            "$numericPart$SP_UNIT"
-        } else {
-            rawValue
-        }
+        return if (numericPart != normalized) "$numericPart${DimensionUnits.SP}" else rawValue
     }
 }

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/cleaner/DimensionValueCleaners.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/cleaner/DimensionValueCleaners.kt
@@ -6,33 +6,101 @@ import org.appdevforall.codeonthego.computervision.domain.parser.DimensionValueS
 import org.appdevforall.codeonthego.computervision.domain.parser.ValueCleaner
 
 internal object DimensionCleaner : ValueCleaner {
+    private const val FUZZY_DIMENSION_THRESHOLD = 60
+    private const val OCR_TRAILING_ZERO_MIN_VALUE = 1000L
+
+    private const val DP_UNIT = "dp"
+    private const val SP_UNIT = "sp"
+    private const val PX_UNIT = "px"
+    private const val IN_UNIT = "in"
+    private const val MM_UNIT = "mm"
+    private const val PT_UNIT = "pt"
+
+    private const val OCR_SP_UNIT = "5p"
+    private const val OCR_DUPLICATED_DP_UNIT = "ddp"
+    private const val OCR_DP_ZERO_UNIT = "d0"
+    private const val OCR_DP_LETTER_O_UNIT = "do"
+    private const val OCR_DP_LETTER_E_UNIT = "de"
+
+    private const val OCR_DP_NOISE_D = 'd'
+    private const val OCR_DP_NOISE_P = 'p'
+
+    private val noisyDimensionSuffixes = listOf(
+        OCR_DUPLICATED_DP_UNIT,
+        DP_UNIT,
+        OCR_DP_ZERO_UNIT,
+        OCR_DP_LETTER_O_UNIT,
+        OCR_DP_LETTER_E_UNIT,
+        SP_UNIT,
+        OCR_SP_UNIT,
+        PX_UNIT,
+        IN_UNIT,
+        MM_UNIT,
+        PT_UNIT
+    )
+
     /** Resolves dimensions using fuzzy scores and numeric OCR corrections. */
     override fun clean(rawValue: String): String {
         val trimmedValue = rawValue.trim().lowercase()
         val normalized = trimmedValue.replace(" ", "_")
 
-        if (DimensionValueSet.matchKeywords.any { it in normalized }) return DimensionValueSet.MATCH_PARENT
-        if (DimensionValueSet.wrapKeywords.any { it in normalized }) return DimensionValueSet.WRAP_CONTENT
+        if (DimensionValueSet.matchKeywords.any { it in normalized }) {
+            return DimensionValueSet.MATCH_PARENT
+        }
+
+        if (DimensionValueSet.wrapKeywords.any { it in normalized }) {
+            return DimensionValueSet.WRAP_CONTENT
+        }
 
         val fuzzyResult = FuzzySearch.extractOne(normalized, DimensionValueSet.values)
-        if (fuzzyResult.score >= 60) return fuzzyResult.string
+        if (fuzzyResult.score >= FUZZY_DIMENSION_THRESHOLD) {
+            return fuzzyResult.string
+        }
 
-        val unitMatch = AttributeRegexPatterns.DIMENSION_UNIT_SUFFIX.find(trimmedValue)
-        val originalUnit = unitMatch?.value ?: "dp"
-        val firstToken = trimmedValue.substringBefore(" ")
-        val rawNumber = firstToken.removeSuffix(originalUnit).trim()
-            .let { number -> if (unitMatch != null && number.endsWith("d")) number.dropLast(1) + "0" else number }
+        val compactValue = trimmedValue
+            .replace(" ", "")
+            .replace("_", "")
+
+        val unit = resolveDimensionUnit(compactValue)
+        val rawNumber = removeDimensionUnitNoise(compactValue)
+
         val numericPart = NumberCleaner.clean(rawNumber)
         val numMatch = AttributeRegexPatterns.LEADING_SIGNED_INTEGER.find(numericPart)?.value
             ?: return trimmedValue
+
         val correctedNum = removeOcrTrailingZero(numMatch).trimLeadingZeros()
 
-        return "$correctedNum$originalUnit"
+        return "$correctedNum$unit"
+    }
+
+    private fun resolveDimensionUnit(value: String): String {
+        return when {
+            value.endsWith(SP_UNIT) || value.endsWith(OCR_SP_UNIT) -> SP_UNIT
+            value.endsWith(PX_UNIT) -> PX_UNIT
+            value.endsWith(IN_UNIT) -> IN_UNIT
+            value.endsWith(MM_UNIT) -> MM_UNIT
+            value.endsWith(PT_UNIT) -> PT_UNIT
+            else -> DP_UNIT
+        }
+    }
+
+    private fun removeDimensionUnitNoise(value: String): String {
+        val cleaned = noisyDimensionSuffixes
+            .firstOrNull { suffix -> value.endsWith(suffix) }
+            ?.let { suffix -> value.removeSuffix(suffix) }
+            ?: value
+
+        return cleaned.trimEnd { char ->
+            char == OCR_DP_NOISE_D || char == OCR_DP_NOISE_P
+        }
     }
 
     /** Removes a likely OCR-added trailing zero from unusually large dimensions. */
     private fun removeOcrTrailingZero(num: String): String {
-        val isOcrArtifact = num.endsWith("0") && (num.toLongOrNull() ?: 0L) >= 1000L
+        val numericValue = num.toLongOrNull() ?: 0L
+        val isOcrArtifact = num.endsWith("0") &&
+            numericValue >= OCR_TRAILING_ZERO_MIN_VALUE
+
         return if (isOcrArtifact) num.dropLast(1) else num
     }
 
@@ -41,14 +109,26 @@ internal object DimensionCleaner : ValueCleaner {
         val negative = startsWith("-")
         val digits = if (negative) drop(1) else this
         val trimmed = digits.trimStart('0').ifEmpty { "0" }
+
         return if (negative) "-$trimmed" else trimmed
     }
 }
 
 internal object SpDimensionCleaner : ValueCleaner {
+    private const val SP_UNIT = "sp"
+
     override fun clean(rawValue: String): String {
-        val normalized = rawValue.lowercase().replace(" ", "").replace(AttributeRegexPatterns.SP_SUFFIX, "")
+        val normalized = rawValue
+            .lowercase()
+            .replace(" ", "")
+            .replace(AttributeRegexPatterns.SP_SUFFIX, "")
+
         val numericPart = NumberCleaner.clean(normalized.replace("_", ""))
-        return if (numericPart != normalized) "${numericPart}sp" else rawValue
+
+        return if (numericPart != normalized) {
+            "$numericPart$SP_UNIT"
+        } else {
+            rawValue
+        }
     }
 }

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/widgettag/WidgetTagPrefixes.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/widgettag/WidgetTagPrefixes.kt
@@ -1,0 +1,12 @@
+package org.appdevforall.codeonthego.computervision.domain.widgettag
+
+internal object WidgetTagPrefixes {
+    const val BUTTON = "B-"
+    const val IMAGE_PLACEHOLDER = "P-"
+    const val DROPDOWN = "D-"
+    const val TEXT_ENTRY = "T-"
+    const val CHECKBOX = "C-"
+    const val RADIO = "R-"
+    const val SWITCH = "SW-"
+    const val SLIDER = "S-"
+}

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/converter/CanvasTagExtractorTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/converter/CanvasTagExtractorTest.kt
@@ -1,0 +1,122 @@
+package org.appdevforall.codeonthego.computervision.domain.converter
+
+import android.graphics.RectF
+import org.appdevforall.codeonthego.computervision.domain.WidgetAnnotationMatcher
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionLabels
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
+import org.appdevforall.codeonthego.computervision.domain.model.SketchRegion
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CanvasTagExtractorTest {
+
+    private val extractor = CanvasTagExtractor(WidgetAnnotationMatcher())
+
+    @Test
+    fun `Given_yolo_widget_tag_on_canvas_When_extracting_Then_tag_is_returned`() {
+        val tag = detection(
+            label = DetectionLabels.WIDGET_TAG,
+            text = "B-1",
+            isYolo = true,
+            region = SketchRegion.CANVAS,
+            left = 10f,
+            top = 20f,
+            right = 30f,
+            bottom = 40f
+        )
+
+        val result = extractor.extract(
+            detections = listOf(tag),
+            sourceWidth = 100,
+            sourceHeight = 100,
+            targetWidth = 200,
+            targetHeight = 200
+        )
+
+        assertEquals(1, result.size)
+        assertEquals("B-1", result.single().text)
+        assertEquals(DetectionLabels.WIDGET_TAG, result.single().label)
+    }
+
+    @Test
+    fun `Given_ocr_tag_on_canvas_When_extracting_Then_tag_is_returned`() {
+        val tag = detection(
+            label = DetectionLabels.TEXT,
+            text = "C-1",
+            isYolo = false,
+            region = SketchRegion.CANVAS
+        )
+
+        val result = extractor.extract(
+            detections = listOf(tag),
+            sourceWidth = 100,
+            sourceHeight = 100,
+            targetWidth = 100,
+            targetHeight = 100
+        )
+
+        assertEquals(1, result.size)
+        assertEquals("C-1", result.single().text)
+    }
+
+    @Test
+    fun `Given_tag_outside_canvas_When_extracting_Then_tag_is_ignored`() {
+        val marginTag = detection(
+            label = DetectionLabels.TEXT,
+            text = "B-1",
+            isYolo = false,
+            region = SketchRegion.LEFT_METADATA
+        )
+
+        val result = extractor.extract(
+            detections = listOf(marginTag),
+            sourceWidth = 100,
+            sourceHeight = 100,
+            targetWidth = 100,
+            targetHeight = 100
+        )
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `Given_invalid_yolo_widget_tag_When_extracting_Then_tag_is_ignored`() {
+        val invalidTag = detection(
+            label = DetectionLabels.WIDGET_TAG,
+            text = "invalid",
+            isYolo = true,
+            region = SketchRegion.CANVAS
+        )
+
+        val result = extractor.extract(
+            detections = listOf(invalidTag),
+            sourceWidth = 100,
+            sourceHeight = 100,
+            targetWidth = 100,
+            targetHeight = 100
+        )
+
+        assertTrue(result.isEmpty())
+    }
+
+    private fun detection(
+        label: String,
+        text: String,
+        isYolo: Boolean,
+        region: SketchRegion?,
+        left: Float = 10f,
+        top: Float = 10f,
+        right: Float = 30f,
+        bottom: Float = 30f
+    ): DetectionResult {
+        return DetectionResult(
+            boundingBox = RectF(left, top, right, bottom),
+            label = label,
+            score = 0.99f,
+            text = text,
+            isYolo = isYolo,
+            region = region
+        )
+    }
+}

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/converter/CompoundButtonNormalizerTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/converter/CompoundButtonNormalizerTest.kt
@@ -1,0 +1,171 @@
+package org.appdevforall.codeonthego.computervision.domain.converter
+
+import android.graphics.Rect
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionLabels
+import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CompoundButtonNormalizerTest {
+
+    private val normalizer = CompoundButtonNormalizer()
+
+    @Test
+    fun `Given_radio_detection_near_checkbox_tag_When_normalized_Then_it_becomes_checkbox`() {
+        val radio = box(
+            label = DetectionLabels.RADIO_BUTTON_CHECKED,
+            text = "",
+            x = 100,
+            y = 100,
+            w = 20,
+            h = 20
+        )
+        val checkboxTag = box(
+            label = DetectionLabels.TEXT,
+            text = "C-1",
+            x = 80,
+            y = 95,
+            w = 20,
+            h = 20
+        )
+
+        val result = normalizer.normalizeByNearestTag(
+            boxes = listOf(radio),
+            canvasTags = listOf(checkboxTag)
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(DetectionLabels.CHECKBOX_CHECKED, result.single().label)
+    }
+
+    @Test
+    fun `Given_checkbox_detection_near_radio_tag_When_normalized_Then_it_becomes_radio`() {
+        val checkbox = box(
+            label = DetectionLabels.CHECKBOX_UNCHECKED,
+            text = "",
+            x = 100,
+            y = 100,
+            w = 20,
+            h = 20
+        )
+        val radioTag = box(
+            label = DetectionLabels.TEXT,
+            text = "R-1",
+            x = 80,
+            y = 95,
+            w = 20,
+            h = 20
+        )
+
+        val result = normalizer.normalizeByNearestTag(
+            boxes = listOf(checkbox),
+            canvasTags = listOf(radioTag)
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(DetectionLabels.RADIO_BUTTON_UNCHECKED, result.single().label)
+    }
+
+    @Test
+    fun `Given_compound_detection_far_from_tag_When_normalized_Then_label_is_not_changed`() {
+        val radio = box(
+            label = DetectionLabels.RADIO_BUTTON_UNCHECKED,
+            text = "",
+            x = 100,
+            y = 300,
+            w = 20,
+            h = 20
+        )
+        val checkboxTag = box(
+            label = DetectionLabels.TEXT,
+            text = "C-1",
+            x = 80,
+            y = 50,
+            w = 20,
+            h = 20
+        )
+
+        val result = normalizer.normalizeByNearestTag(
+            boxes = listOf(radio),
+            canvasTags = listOf(checkboxTag)
+        )
+
+        assertEquals(DetectionLabels.RADIO_BUTTON_UNCHECKED, result.single().label)
+    }
+
+    @Test
+    fun `Given_overlapping_same_compound_detections_When_normalized_Then_larger_detection_is_kept`() {
+        val small = box(
+            label = DetectionLabels.CHECKBOX_UNCHECKED,
+            text = "",
+            x = 100,
+            y = 100,
+            w = 16,
+            h = 16
+        )
+        val large = box(
+            label = DetectionLabels.CHECKBOX_UNCHECKED,
+            text = "",
+            x = 98,
+            y = 98,
+            w = 24,
+            h = 24
+        )
+
+        val result = normalizer.normalizeByNearestTag(
+            boxes = listOf(small, large),
+            canvasTags = emptyList()
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(large, result.single())
+    }
+
+    @Test
+    fun `Given_switch_detection_When_normalized_Then_it_is_not_treated_as_compound_button`() {
+        val switch = box(
+            label = DetectionLabels.SWITCH_OFF,
+            text = "Remember me",
+            x = 100,
+            y = 100,
+            w = 80,
+            h = 40
+        )
+        val checkboxTag = box(
+            label = DetectionLabels.TEXT,
+            text = "C-1",
+            x = 80,
+            y = 95,
+            w = 20,
+            h = 20
+        )
+
+        val result = normalizer.normalizeByNearestTag(
+            boxes = listOf(switch),
+            canvasTags = listOf(checkboxTag)
+        )
+
+        assertEquals(DetectionLabels.SWITCH_OFF, result.single().label)
+    }
+
+    private fun box(
+        label: String,
+        text: String,
+        x: Int,
+        y: Int,
+        w: Int,
+        h: Int
+    ): ScaledBox {
+        return ScaledBox(
+            label = label,
+            text = text,
+            x = x,
+            y = y,
+            w = w,
+            h = h,
+            centerX = x + w / 2,
+            centerY = y + h / 2,
+            rect = Rect(x, y, x + w, y + h)
+        )
+    }
+}

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/converter/ImagePlaceholderDuplicateFilterTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/converter/ImagePlaceholderDuplicateFilterTest.kt
@@ -1,0 +1,86 @@
+package org.appdevforall.codeonthego.computervision.domain.converter
+
+import android.graphics.Rect
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionLabels
+import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImagePlaceholderDuplicateFilterTest {
+
+    private val filter = ImagePlaceholderDuplicateFilter()
+
+    @Test
+    fun `Given_annotated_image_and_small_nearby_duplicate_When_filtered_Then_duplicate_is_removed`() {
+        val annotated = imageBox(x = 100, y = 100, w = 100, h = 100)
+        val duplicate = imageBox(x = 120, y = 205, w = 20, h = 20)
+        val button = box(label = DetectionLabels.BUTTON, text = "Login", x = 0, y = 0, w = 80, h = 40)
+
+        val result = filter.filter(
+            uiElements = listOf(button, annotated, duplicate),
+            annotations = mapOf(annotated to "id: img_logo")
+        )
+
+        assertEquals(listOf(button, annotated), result)
+    }
+
+    @Test
+    fun `Given_no_annotated_images_When_filtered_Then_all_elements_are_kept`() {
+        val first = imageBox(x = 100, y = 100, w = 100, h = 100)
+        val second = imageBox(x = 120, y = 205, w = 20, h = 20)
+
+        val result = filter.filter(
+            uiElements = listOf(first, second),
+            annotations = emptyMap()
+        )
+
+        assertEquals(listOf(first, second), result)
+    }
+
+    @Test
+    fun `Given_far_image_placeholder_When_filtered_Then_it_is_kept`() {
+        val annotated = imageBox(x = 100, y = 100, w = 100, h = 100)
+        val farImage = imageBox(x = 280, y = 400, w = 20, h = 20)
+
+        val result = filter.filter(
+            uiElements = listOf(annotated, farImage),
+            annotations = mapOf(annotated to "id: img_logo")
+        )
+
+        assertTrue(result.contains(annotated))
+        assertTrue(result.contains(farImage))
+    }
+
+    private fun imageBox(x: Int, y: Int, w: Int, h: Int): ScaledBox {
+        return box(
+            label = DetectionLabels.IMAGE_PLACEHOLDER,
+            text = "",
+            x = x,
+            y = y,
+            w = w,
+            h = h
+        )
+    }
+
+    private fun box(
+        label: String,
+        text: String,
+        x: Int,
+        y: Int,
+        w: Int,
+        h: Int
+    ): ScaledBox {
+        return ScaledBox(
+            label = label,
+            text = text,
+            x = x,
+            y = y,
+            w = w,
+            h = h,
+            centerX = x + w / 2,
+            centerY = y + h / 2,
+            rect = Rect(x, y, x + w, y + h)
+        )
+    }
+}

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/converter/TextAssociationProcessorTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/converter/TextAssociationProcessorTest.kt
@@ -1,0 +1,112 @@
+package org.appdevforall.codeonthego.computervision.domain.converter
+
+import android.graphics.Rect
+import org.appdevforall.codeonthego.computervision.domain.WidgetAnnotationMatcher
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionLabels
+import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TextAssociationProcessorTest {
+
+    private val processor = TextAssociationProcessor(WidgetAnnotationMatcher())
+
+    @Test
+    fun `Given_labelable_widget_and_nearby_text_When_associating_Then_text_is_assigned_and_text_box_is_consumed`() {
+        val checkbox = box(
+            label = DetectionLabels.CHECKBOX_CHECKED,
+            text = "",
+            x = 100,
+            y = 100,
+            w = 20,
+            h = 20
+        )
+        val label = box(
+            label = DetectionLabels.TEXT,
+            text = "Milk",
+            x = 130,
+            y = 100,
+            w = 40,
+            h = 20
+        )
+
+        val result = processor.associateText(listOf(checkbox, label))
+
+        assertEquals(1, result.size)
+        assertEquals(DetectionLabels.CHECKBOX_CHECKED, result.single().label)
+        assertEquals("Milk", result.single().text)
+    }
+
+    @Test
+    fun `Given_tag_like_text_When_finalizing_ui_elements_Then_tag_text_is_removed`() {
+        val button = box(
+            label = DetectionLabels.BUTTON,
+            text = "Login",
+            x = 100,
+            y = 100,
+            w = 80,
+            h = 40
+        )
+        val tagText = box(
+            label = DetectionLabels.TEXT,
+            text = "B-1",
+            x = 80,
+            y = 100,
+            w = 20,
+            h = 20
+        )
+        val normalText = box(
+            label = DetectionLabels.TEXT,
+            text = "Welcome",
+            x = 100,
+            y = 200,
+            w = 80,
+            h = 20
+        )
+
+        val result = processor.finalizeUiElements(listOf(button, tagText, normalText))
+
+        assertTrue(result.contains(button))
+        assertTrue(result.contains(normalText))
+        assertFalse(result.contains(tagText))
+    }
+
+    @Test
+    fun `Given_widget_When_finalizing_ui_elements_Then_widget_is_kept`() {
+        val switch = box(
+            label = DetectionLabels.SWITCH_OFF,
+            text = "Remember me",
+            x = 100,
+            y = 100,
+            w = 100,
+            h = 40
+        )
+
+        val result = processor.finalizeUiElements(listOf(switch))
+
+        assertEquals(listOf(switch), result)
+    }
+
+    private fun box(
+        label: String,
+        text: String,
+        x: Int,
+        y: Int,
+        w: Int,
+        h: Int
+    ): ScaledBox {
+        return ScaledBox(
+            label = label,
+            text = text,
+            x = x,
+            y = y,
+            w = w,
+            h = h,
+            centerX = x + w / 2,
+            centerY = y + h / 2,
+            rect = Rect(x, y, x + w, y + h)
+        )
+    }
+}

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/converter/UiCandidateExtractorTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/converter/UiCandidateExtractorTest.kt
@@ -1,0 +1,121 @@
+package org.appdevforall.codeonthego.computervision.domain.converter
+
+import android.graphics.RectF
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionLabels
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
+import org.appdevforall.codeonthego.computervision.domain.model.SketchRegion
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UiCandidateExtractorTest {
+
+    private val extractor = UiCandidateExtractor()
+
+    @Test
+    fun `Given_invalid_widget_tag_When_extracting_candidates_Then_it_is_removed`() {
+        val invalidTag = detection(
+            label = DetectionLabels.WIDGET_TAG,
+            text = "not-a-tag",
+            isYolo = true,
+            region = SketchRegion.CANVAS
+        )
+        val button = detection(
+            label = DetectionLabels.BUTTON,
+            text = "Login",
+            isYolo = true,
+            region = SketchRegion.CANVAS
+        )
+
+        val result = extractor.extract(listOf(invalidTag, button))
+
+        assertEquals(listOf(button), result)
+    }
+
+    @Test
+    fun `Given_switches_in_same_vertical_band_When_extracting_candidates_Then_only_one_switch_is_kept`() {
+        val firstSwitch = detection(
+            label = DetectionLabels.SWITCH_OFF,
+            text = "",
+            top = 100f,
+            bottom = 130f,
+            region = SketchRegion.CANVAS
+        )
+        val duplicatedSwitch = detection(
+            label = DetectionLabels.SWITCH_ON,
+            text = "",
+            top = 105f,
+            bottom = 135f,
+            region = SketchRegion.CANVAS
+        )
+
+        val result = extractor.extract(listOf(firstSwitch, duplicatedSwitch))
+
+        assertEquals(1, result.size)
+        assertEquals(firstSwitch, result.single())
+    }
+
+    @Test
+    fun `Given_cross_boundary_canvas_text_When_extracting_candidates_Then_valid_text_is_kept`() {
+        val text = detection(
+            label = DetectionLabels.TEXT,
+            text = "Remember me",
+            isYolo = false,
+            region = SketchRegion.CROSS_BOUNDARY
+        )
+
+        val result = extractor.extract(listOf(text))
+
+        assertEquals(listOf(text), result)
+    }
+
+    @Test
+    fun `Given_margin_detection_When_extracting_candidates_Then_it_is_removed`() {
+        val marginText = detection(
+            label = DetectionLabels.TEXT,
+            text = "B-1 width 100dp",
+            isYolo = false,
+            region = SketchRegion.LEFT_METADATA
+        )
+
+        val result = extractor.extract(listOf(marginText))
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `Given_canvas_metadata_text_When_extracting_candidates_Then_it_is_removed`() {
+        val metadataText = detection(
+            label = DetectionLabels.TEXT,
+            text = "layout_width:100dp",
+            isYolo = false,
+            region = SketchRegion.CROSS_BOUNDARY
+        )
+
+        val result = extractor.extract(listOf(metadataText))
+
+        assertFalse(result.contains(metadataText))
+    }
+
+    private fun detection(
+        label: String,
+        text: String,
+        left: Float = 100f,
+        top: Float = 100f,
+        right: Float = 200f,
+        bottom: Float = 130f,
+        score: Float = 0.99f,
+        isYolo: Boolean = true,
+        region: SketchRegion? = null
+    ): DetectionResult {
+        return DetectionResult(
+            boundingBox = RectF(left, top, right, bottom),
+            label = label,
+            score = score,
+            text = text,
+            isYolo = isYolo,
+            region = region
+        )
+    }
+}

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/model/DetectionLabelsTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/model/DetectionLabelsTest.kt
@@ -1,0 +1,40 @@
+package org.appdevforall.codeonthego.computervision.domain.model
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DetectionLabelsTest {
+
+    @Test
+    fun `Given_checkbox_or_radio_label_When_checking_compound_button_Then_returns_true`() {
+        assertTrue(DetectionLabels.isCompoundButton(DetectionLabels.CHECKBOX_CHECKED))
+        assertTrue(DetectionLabels.isCompoundButton(DetectionLabels.CHECKBOX_UNCHECKED))
+        assertTrue(DetectionLabels.isCompoundButton(DetectionLabels.RADIO_BUTTON_CHECKED))
+        assertTrue(DetectionLabels.isCompoundButton(DetectionLabels.RADIO_BUTTON_UNCHECKED))
+    }
+
+    @Test
+    fun `Given_switch_label_When_checking_compound_button_Then_returns_false`() {
+        assertFalse(DetectionLabels.isCompoundButton(DetectionLabels.SWITCH_ON))
+        assertFalse(DetectionLabels.isCompoundButton(DetectionLabels.SWITCH_OFF))
+    }
+
+    @Test
+    fun `Given_checkable_labels_When_checking_state_Then_checked_state_is_detected`() {
+        assertTrue(DetectionLabels.isChecked(DetectionLabels.CHECKBOX_CHECKED))
+        assertTrue(DetectionLabels.isChecked(DetectionLabels.RADIO_BUTTON_CHECKED))
+        assertTrue(DetectionLabels.isChecked(DetectionLabels.SWITCH_ON))
+
+        assertFalse(DetectionLabels.isChecked(DetectionLabels.CHECKBOX_UNCHECKED))
+        assertFalse(DetectionLabels.isChecked(DetectionLabels.RADIO_BUTTON_UNCHECKED))
+        assertFalse(DetectionLabels.isChecked(DetectionLabels.SWITCH_OFF))
+    }
+
+    @Test
+    fun `Given_image_placeholder_label_When_checked_Then_returns_true`() {
+        assertTrue(DetectionLabels.isImagePlaceholder(DetectionLabels.IMAGE_PLACEHOLDER))
+        assertTrue(DetectionLabels.isImagePlaceholder("image_placeholder_extra"))
+        assertFalse(DetectionLabels.isImagePlaceholder(DetectionLabels.BUTTON))
+    }
+}


### PR DESCRIPTION
## Description

Fixed XML generation for grouped radio buttons and checkboxes when noisy detections cause overlapping or incorrect control types. The change normalizes grouped controls using nearby canvas tags, preserves the expected radio/checkbox structure, prevents incorrect duplicated detections from affecting the generated XML, and improves noisy dimension recovery.

The PR also refactors the XML conversion pipeline into smaller responsibilities to make the grouping fix easier to maintain, test, and extend.

## Details

This PR includes two main parts:

* A functional fix for radio and checkbox grouping, including noisy OCR dimension handling and duplicate detection cleanup.
* A refactor of the XML conversion flow, extracting responsibilities such as UI candidate extraction, canvas tag extraction, compound button normalization, text association, image placeholder filtering, and shared detection label handling.


https://github.com/user-attachments/assets/93d68f85-ddbd-46e6-ac26-cbb1a0409f8d

### Sketch tested

<img width="785" height="954" alt="Screenshot 2026-05-23 at 10 05 14 AM" src="https://github.com/user-attachments/assets/f56da09b-252f-44b6-9484-3f59d7fa2d58" />


Unit tests were added to protect the fixed behavior and prevent regressions around grouped controls, switches, internal tags, duplicate placeholders, and refactored pipeline components.

## Ticket

[ADFA-4278](https://appdevforall.atlassian.net/browse/ADFA-4278)

## Observation

The refactor supports the fix by separating the XML conversion responsibilities, but the main purpose of this PR is to recover correct radio and checkbox grouping in the generated XML.

[ADFA-4278]: https://appdevforall.atlassian.net/browse/ADFA-4278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ