### PR TITLE
ADFA-4299 | Avoid duplicated ImageView img prefix

### DIFF
--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/cleaner/IdCleaner.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/cleaner/IdCleaner.kt
@@ -2,31 +2,29 @@ package org.appdevforall.codeonthego.computervision.domain.parser.cleaner
 
 import kotlin.math.abs
 import me.xdrop.fuzzywuzzy.FuzzySearch
+import org.appdevforall.codeonthego.computervision.domain.model.WidgetTypes
 import org.appdevforall.codeonthego.computervision.domain.parser.ValueCleaner
 import org.appdevforall.codeonthego.computervision.domain.parser.patterns.AttributeKeyPatterns
 import org.appdevforall.codeonthego.computervision.domain.parser.patterns.CoreParserPatterns
+import org.appdevforall.codeonthego.computervision.domain.parser.patterns.IdPatterns
 import org.appdevforall.codeonthego.computervision.domain.parser.patterns.ResourceNamePatterns
+import org.appdevforall.codeonthego.computervision.domain.xml.AndroidWidgetTags
 
 internal object IdCleaner : ValueCleaner {
-    private const val SWITCH_TAG = "Switch"
-    private const val IMAGE_VIEW_TAG = "ImageView"
-    private const val SWITCH_ID_TARGET = "switch"
-    private const val IMAGE_VIEW_ID_PREFIX = "im"
-    private const val IMAGE_VIEW_ID_VIEW_TOKEN = "view"
     private const val SWITCH_ID_OCR_THRESHOLD = 70
     private const val IMAGE_VIEW_ID_OCR_THRESHOLD = 80
     private val idVocabulary = listOf(
-        "cb", "rb", "group", "checkbox", "radio", "btn", "button", "text", "view",
-        "img", "image", "input", "switch"
+        "cb", "rb", "group", "checkbox", "radio", "btn", "button", "text", IdPatterns.IMAGE_VIEW_ID_VIEW_TOKEN,
+        "img", "image", "input", WidgetTypes.SWITCH
     )
-    private val switchIdTargets = listOf(SWITCH_ID_TARGET)
-    private val imageViewIdPrefixTargets = listOf(IMAGE_VIEW_ID_PREFIX, "img", "image")
-    private val imageViewIdViewTargets = listOf(IMAGE_VIEW_ID_VIEW_TOKEN)
+    private val switchIdTargets = listOf(WidgetTypes.SWITCH)
+    private val imageViewIdPrefixTargets = listOf(IdPatterns.IMAGE_VIEW_ID_PREFIX, "img", "image")
+    private val imageViewIdViewTargets = listOf(IdPatterns.IMAGE_VIEW_ID_VIEW_TOKEN)
 
     override fun clean(rawValue: String): String {
         val cleaned = rawValue.trim().lowercase()
             .replace(AttributeKeyPatterns.OCR_IM_OR_M_CONFUSION) { match ->
-                if (match.value == "inm") "im" else "m"
+                if (match.value == "inm") IdPatterns.IMAGE_VIEW_ID_PREFIX else "m"
             }
             .replace(ResourceNamePatterns.RESOURCE_NAME_UNSAFE_CHARS, "_")
             .replace(CoreParserPatterns.MULTIPLE_UNDERSCORES, "_")
@@ -39,7 +37,7 @@ internal object IdCleaner : ValueCleaner {
         val cleaned = clean(rawValue)
         val tokens = cleaned.split('_').filter { it.isNotBlank() }
         return normalizeSwitchIdIfNeeded(tokens, tag)
-            ?: normalizeImageViewIdIfNeeded(tokens, tag)
+            ?: normalizeImageViewId(rawValue, tokens, tag)
             ?: cleaned
     }
 
@@ -65,8 +63,8 @@ internal object IdCleaner : ValueCleaner {
     }
 
     private fun normalizeSwitchIdIfNeeded(tokens: List<String>, tag: String): String? {
-        if (tag != SWITCH_TAG || !isSwitchIdOcrCandidate(tokens)) return null
-        return buildId(SWITCH_ID_TARGET, extractTrailingNumber(tokens))
+        if (tag != AndroidWidgetTags.SWITCH || !isSwitchIdOcrCandidate(tokens)) return null
+        return buildId(WidgetTypes.SWITCH, extractTrailingNumber(tokens))
     }
 
     /** Accepts a switch ID candidate when its fuzzy score reaches the switch threshold. */
@@ -75,9 +73,32 @@ internal object IdCleaner : ValueCleaner {
         return fuzzyTokenScore(firstToken, switchIdTargets) >= SWITCH_ID_OCR_THRESHOLD
     }
 
-    private fun normalizeImageViewIdIfNeeded(tokens: List<String>, tag: String): String? {
-        if (tag != IMAGE_VIEW_TAG || !isImageViewIdOcrCandidate(tokens)) return null
-        return buildId(IMAGE_VIEW_ID_PREFIX, IMAGE_VIEW_ID_VIEW_TOKEN, extractTrailingNumber(tokens))
+    private fun normalizeImageViewId(rawValue: String, tokens: List<String>, tag: String): String? {
+        if (tag != AndroidWidgetTags.IMAGE_VIEW) return null
+
+        return removeLeakedImagePrefixIfNeeded(rawValue, tokens)
+            ?: recoverGenericImageViewIdIfNeeded(tokens)
+    }
+
+    private fun removeLeakedImagePrefixIfNeeded(
+        rawValue: String,
+        tokens: List<String>
+    ): String? {
+        if (tokens.size < 3) return null
+        if (!rawValue.trim().contains(CoreParserPatterns.WHITESPACE)) return null
+        if (tokens.first() !in imageViewIdPrefixTargets) return null
+
+        val remainingTokens = tokens.drop(1)
+        val remainingId = remainingTokens.joinToString("_")
+
+        return remainingId.takeIf {
+            remainingTokens.firstOrNull() in imageViewIdPrefixTargets
+        }
+    }
+
+    private fun recoverGenericImageViewIdIfNeeded(tokens: List<String>): String? {
+        if (!isImageViewIdOcrCandidate(tokens)) return null
+        return buildId(IdPatterns.IMAGE_VIEW_ID_PREFIX, IdPatterns.IMAGE_VIEW_ID_VIEW_TOKEN, extractTrailingNumber(tokens))
     }
 
     private fun isImageViewIdOcrCandidate(tokens: List<String>): Boolean {

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/patterns/IdPatterns.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/patterns/IdPatterns.kt
@@ -1,11 +1,26 @@
 package org.appdevforall.codeonthego.computervision.domain.parser.patterns
 
 internal object IdPatterns {
+    const val IMAGE_VIEW_ID_PREFIX = "im"
+    const val IMAGE_VIEW_ID_VIEW_TOKEN = "view"
+
     /** Validates an unkeyed OCR fragment before considering it as a corroborated EditText ID. */
     val BARE_EDIT_TEXT_ID_CANDIDATE = Regex("[A-Za-z][A-Za-z0-9_]{2,}")
 
     /** Extracts an explicit ID value from ImageView metadata. */
     val EXPLICIT_LOWER_ID = Regex("\\bid\\s*:\\s*([a-z0-9_-]+)", RegexOption.IGNORE_CASE)
+
+    /** Matches canonical checkbox group IDs used to derive child CheckBox IDs. */
+    val CHECKBOX_GROUP_ID = Regex("^cb_group_\\d+$")
+
+    /** Matches compact checkbox group OCR variants like `cbgraup2`. */
+    val COMPACT_CHECKBOX_GROUP_ID = Regex("^cbgr[oa]up?(\\d+)$")
+
+    /** Matches RadioButton child IDs that accidentally contain a radio group ID. */
+    val RADIO_BUTTON_GROUP_CHILD_ID = Regex("^rb_group(?:_\\d+)?(?:_|$).*")
+
+    /** Matches RadioButton child IDs that accidentally contain a RadioGroup ID. */
+    val RADIO_GROUP_CHILD_ID = Regex("^radio_group(?:_\\d+)?(?:_|$).*")
 
     /** Matches a clean `id` key or OCR ID alias followed by a value. */
     fun keyedIdValue(idKeyPattern: String): Regex {

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/recovery/EditTextAttributeRecovery.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/recovery/EditTextAttributeRecovery.kt
@@ -60,7 +60,7 @@ internal object EditTextAttributeRecovery {
         return text.contains(TextPatterns.EDIT_TEXT_METADATA_LEAKAGE)
     }
 
-    /** Selects a uniquely longest repeated unkeyed ID candidate after password metadata. */
+    /** Selects an unkeyed ID candidate after password metadata while keeping single-token noise out. */
     private fun recoverBareEditTextId(annotation: String): String? {
         val parts = annotation.split(PIPE_DELIMITER).map { it.trim() }
         val passwordIndex = parts.indexOfFirst { isLikelyPasswordInput(it) }
@@ -76,7 +76,8 @@ internal object EditTextAttributeRecovery {
 
         if (candidates.size < MIN_UNKEYED_ID_CORROBORATION_COUNT) return null
         val longestLength = candidates.maxOfOrNull { it.length } ?: return null
-        return candidates.filter { it.length == longestLength }.singleOrNull()
+        return candidates.singleOrNull { it.length == longestLength }
+            ?: candidates.firstOrNull()
     }
 
     private fun recoverExplicitTextValue(annotation: String): String? {

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/AndroidConstants.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/AndroidConstants.kt
@@ -13,6 +13,13 @@ object AndroidConstants {
     const val DEFAULT_TEXT_SIZE = "16sp"
 }
 
+object AndroidIdLabels {
+    const val CHECKBOX_GROUP = "cb_group"
+    const val RADIO_BUTTON = "radio_button"
+    const val RADIO_GROUP = "radio_group"
+    const val RADIO_BUTTON_GROUP = "rb_group"
+}
+
 object AndroidWidgetTags {
     const val LINEAR_LAYOUT = "LinearLayout"
     const val RADIO_GROUP = "RadioGroup"

--- a/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/WidgetFactory.kt
+++ b/sketch-to-ui-plugin/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/WidgetFactory.kt
@@ -2,18 +2,20 @@ package org.appdevforall.codeonthego.computervision.domain.xml
 
 import org.appdevforall.codeonthego.computervision.domain.model.LayoutItem
 import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionLabels
 import org.appdevforall.codeonthego.computervision.domain.parser.AttributeKey
 import org.appdevforall.codeonthego.computervision.domain.parser.FuzzyAttributeParser
+import org.appdevforall.codeonthego.computervision.domain.parser.patterns.IdPatterns
+import org.appdevforall.codeonthego.computervision.domain.parser.patterns.ResourceNamePatterns
 
 class WidgetFactory(
     private val context: XmlContext,
     private val annotations: Map<ScaledBox, String>,
     private val selectedImageOverrides: Map<ScaledBox, String> = emptyMap()
 ) {
-    private val checkboxGroupIdPattern = Regex("^cb_group_\\d+$")
     private val radioChildGroupIdPatterns = listOf(
-        Regex("^rb_group(?:_\\d+)?(?:_|$).*"),
-        Regex("^radio_group(?:_\\d+)?(?:_|$).*")
+        IdPatterns.RADIO_BUTTON_GROUP_CHILD_ID,
+        IdPatterns.RADIO_GROUP_CHILD_ID
     )
 
     fun createWidgets(item: LayoutItem): List<AndroidWidget> = when (item) {
@@ -40,11 +42,11 @@ class WidgetFactory(
         val widgets = mutableListOf<AndroidWidget>()
 
         val dropdownTitle = box.text
-            .takeIf { box.label == "dropdown" }
+            .takeIf { box.label == DetectionLabels.DROPDOWN }
             ?.let(::extractDropdownTitle)
 
         if (dropdownTitle != null) {
-            val titleBox = box.copy(label = "text", text = dropdownTitle)
+            val titleBox = box.copy(label = DetectionLabels.TEXT, text = dropdownTitle)
 
             val titleAttrs = mapOf(
                 AttributeKey.WIDTH.xmlName to AndroidConstants.WRAP_CONTENT,
@@ -71,11 +73,16 @@ class WidgetFactory(
 
     private fun createRadioGroup(item: LayoutItem.RadioGroup): List<AndroidWidget> {
         val groupAnnotation = item.boxes.firstNotNullOfOrNull { annotations[it] }
-        val fullGroupAttrs = FuzzyAttributeParser.parse(groupAnnotation, "RadioGroup")
+        val fullGroupAttrs = FuzzyAttributeParser.parse(groupAnnotation, AndroidWidgetTags.RADIO_GROUP)
 
-        val groupId = resolveRadioGroupId(fullGroupAttrs["android:id"]?.substringAfterLast('/'))
+        val groupId = resolveRadioGroupId(fullGroupAttrs[AttributeKey.ID.xmlName]?.substringAfterLast('/'))
 
-        val groupStructuralAttrs = setOf("android:id", "android:layout_width", "android:layout_height", "android:orientation")
+        val groupStructuralAttrs = setOf(
+            AttributeKey.ID.xmlName,
+            AttributeKey.WIDTH.xmlName,
+            AttributeKey.HEIGHT.xmlName,
+            AttributeKey.ORIENTATION.xmlName
+        )
         // Group metadata can contain style attributes; visible option labels must stay with each RadioButton's OCR text.
         val sharedAttrs = fullGroupAttrs.filterKeys {
             it !in groupStructuralAttrs && it != AttributeKey.TEXT.xmlName
@@ -84,63 +91,68 @@ class WidgetFactory(
         var checkedId: String? = null
 
         val children = item.boxes.mapIndexed { index, box ->
-            val parsedAttrs = (sharedAttrs + FuzzyAttributeParser.parse(annotations[box], "RadioButton")).toMutableMap()
+            val childAnnotation = annotations[box]
+            val childAttrs = FuzzyAttributeParser.parse(childAnnotation, AndroidWidgetTags.RADIO_BUTTON)
+                .filterKeys { key -> childAnnotation != groupAnnotation || key !in groupStructuralAttrs }
+            val parsedAttrs = (sharedAttrs + childAttrs).toMutableMap()
             if (box.text.isNotBlank()) {
                 parsedAttrs.remove(AttributeKey.TEXT.xmlName)
             }
 
-            if (parsedAttrs["android:id"] == fullGroupAttrs["android:id"]) {
-                parsedAttrs.remove("android:id")
+            if (parsedAttrs[AttributeKey.ID.xmlName] == fullGroupAttrs[AttributeKey.ID.xmlName]) {
+                parsedAttrs.remove(AttributeKey.ID.xmlName)
             }
 
-            val requestedId = parsedAttrs["android:id"]?.substringAfterLast('/')
+            val requestedId = parsedAttrs[AttributeKey.ID.xmlName]?.substringAfterLast('/')
             val childId = if (requestedId != null && radioChildGroupIdPatterns.any { it.matches(requestedId) }) {
-                context.nextId("radio_button")
+                context.nextId(AndroidIdLabels.RADIO_BUTTON)
             } else {
-                context.resolveId(requestedId, "radio_button")
+                context.resolveId(requestedId, AndroidIdLabels.RADIO_BUTTON)
             }
 
-            val isChecked = box.label == "radio_button_checked" || parsedAttrs["android:checked"]?.equals("true", ignoreCase = true) == true
+            val isChecked = box.label == DetectionLabels.RADIO_BUTTON_CHECKED ||
+                parsedAttrs[AttributeKey.CHECKED.xmlName]?.equals(AndroidConstants.TRUE, ignoreCase = true) == true
             if (isChecked) {
                 checkedId = childId
-                parsedAttrs["android:checked"] = "true"
+                parsedAttrs[AttributeKey.CHECKED.xmlName] = AndroidConstants.TRUE
             } else {
-                parsedAttrs["android:checked"] = "false"
+                parsedAttrs[AttributeKey.CHECKED.xmlName] = AndroidConstants.FALSE
             }
 
-            val extraAttrs = if (item.orientation == "horizontal") {
+            val extraAttrs = if (item.orientation == AndroidConstants.ORIENTATION_HORIZONTAL) {
                 getMarginEndForHorizontalGap(item.boxes, index)
             } else emptyMap()
 
             createSimpleWidget(box, parsedAttrsOverride = parsedAttrs, idOverride = childId, extraAttrs = extraAttrs)
         }
 
-        val textStyleAttrs = setOf("android:textColor", "android:textSize", "android:textStyle", "android:fontFamily")
+        val textStyleAttrs = setOf(
+            AttributeKey.TEXT_COLOR.xmlName,
+            AttributeKey.TEXT_SIZE.xmlName,
+            AttributeKey.TEXT_STYLE.xmlName,
+            AttributeKey.FONT_FAMILY.xmlName
+        )
         val groupFinalAttrs = fullGroupAttrs.filterKeys { it !in textStyleAttrs }.toMutableMap()
-        groupFinalAttrs["android:id"] = groupId
+        groupFinalAttrs[AttributeKey.ID.xmlName] = groupId
 
         return listOf(RadioGroupWidget(groupFinalAttrs, children, item.orientation, checkedId))
     }
 
     private fun createCheckboxGroup(item: LayoutItem.CheckboxGroup): List<AndroidWidget> {
         val groupAnnotation = item.boxes.firstNotNullOfOrNull { annotations[it] }
-        val parsedAttrs = FuzzyAttributeParser.parse(groupAnnotation, "CheckBox")
+        val parsedAttrs = FuzzyAttributeParser.parse(groupAnnotation, AndroidWidgetTags.CHECK_BOX)
 
-        val requestedId = parsedAttrs["android:id"]?.substringAfterLast('/')
-        val baseId = if (requestedId != null && checkboxGroupIdPattern.matches(requestedId)) {
-            context.resolveId(requestedId, "cb_group")
-        } else {
-            context.nextId("cb_group", initialIndex = 1)
-        }
+        val requestedId = parsedAttrs[AttributeKey.ID.xmlName]?.substringAfterLast('/')
+        val baseId = resolveCheckboxGroupId(requestedId)
 
         return item.boxes.mapIndexed { index, box ->
             val suffix = ('a' + index).toString()
             val childId = "${baseId}_$suffix"
 
             val safeAttrs = parsedAttrs.toMutableMap()
-            safeAttrs.remove("android:id")
+            safeAttrs.remove(AttributeKey.ID.xmlName)
 
-            val extraAttrs = if (item.orientation == "horizontal") {
+            val extraAttrs = if (item.orientation == AndroidConstants.ORIENTATION_HORIZONTAL) {
                 getMarginEndForHorizontalGap(item.boxes, index)
             } else emptyMap()
 
@@ -160,7 +172,7 @@ class WidgetFactory(
             ?: FuzzyAttributeParser.parse(rawAnnotation, tag).toMutableMap()
 
         selectedImageOverrides[box]?.let { drawableReference ->
-            parsedAttrs["android:src"] = drawableReference
+            parsedAttrs[AttributeKey.SRC.xmlName] = drawableReference
         }
 
         return AndroidWidget.create(box, parsedAttrs).apply {
@@ -175,7 +187,7 @@ class WidgetFactory(
             .replace(Regex("^[vV]\\s+"), "")
             .trim()
 
-        return cleaned.takeIf { it.isNotBlank() && !it.equals("dropdown", ignoreCase = true) }
+        return cleaned.takeIf { it.isNotBlank() && !it.equals(DetectionLabels.DROPDOWN, ignoreCase = true) }
     }
 
     /** Calculates the non-negative horizontal gap to the next box as an end margin. */
@@ -184,7 +196,7 @@ class WidgetFactory(
         val currentBox = boxes[currentIndex]
         val nextBox = boxes[currentIndex + 1]
         val gap = maxOf(0, nextBox.x - (currentBox.x + currentBox.w))
-        return mapOf("android:layout_marginEnd" to "${gap}dp")
+        return mapOf(AttributeKey.LAYOUT_MARGIN_END.xmlName to "${gap}dp")
     }
 
     private fun resolveRadioGroupId(requestedId: String?): String {
@@ -192,10 +204,28 @@ class WidgetFactory(
         if (requestedId != null) {
             val normalizedId = requestedId.lowercase()
             when {
-                normalizedId.startsWith("radio_grou") -> cleanId = "radio_group"
-                normalizedId.startsWith("rb_grou") || normalizedId.startsWith("rb_group") -> cleanId = "rb_group"
+                normalizedId.startsWith("radio_grou") -> cleanId = AndroidIdLabels.RADIO_GROUP
+                normalizedId.startsWith("rb_grou") || normalizedId.startsWith(AndroidIdLabels.RADIO_BUTTON_GROUP) ->
+                    cleanId = AndroidIdLabels.RADIO_BUTTON_GROUP
             }
         }
-        return context.resolveId(cleanId, "radio_group")
+        return context.resolveId(cleanId, AndroidIdLabels.RADIO_GROUP)
+    }
+
+    private fun resolveCheckboxGroupId(requestedId: String?): String {
+        if (requestedId == null) return context.nextId(AndroidIdLabels.CHECKBOX_GROUP, initialIndex = 1)
+        if (IdPatterns.CHECKBOX_GROUP_ID.matches(requestedId)) {
+            return context.resolveId(requestedId, AndroidIdLabels.CHECKBOX_GROUP)
+        }
+
+        val compactId = requestedId.lowercase().replace(ResourceNamePatterns.NON_ALPHANUMERIC_LOWER, "")
+        val recoveredSuffix = IdPatterns.COMPACT_CHECKBOX_GROUP_ID.matchEntire(compactId)?.groupValues?.getOrNull(1)
+        val cleanId = recoveredSuffix?.let { "${AndroidIdLabels.CHECKBOX_GROUP}_$it" }
+
+        return if (cleanId != null) {
+            context.resolveId(cleanId, AndroidIdLabels.CHECKBOX_GROUP)
+        } else {
+            context.nextId(AndroidIdLabels.CHECKBOX_GROUP, initialIndex = 1)
+        }
     }
 }

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParserTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParserTest.kt
@@ -485,6 +485,26 @@ class FuzzyAttributeParserTest {
     }
 
     @Test
+    fun `Given_leaked_image_prefix_before_image_id_When_parsed_Then_clean_image_id_is_used`() {
+        val annotation = "height:64do | width:64dp | src:logo.png | icl:img. | img_logo"
+        val result = FuzzyAttributeParser.parse(annotation, "ImageView")
+
+        assertEquals("64dp", result["android:layout_height"])
+        assertEquals("64dp", result["android:layout_width"])
+        assertEquals("@drawable/logo", result["android:src"])
+        assertEquals("img_logo", result["android:id"])
+    }
+
+    @Test
+    fun `Given_explicit_image_ids_When_parsed_Then_ids_are_not_duplicated_or_rewritten`() {
+        val ids = listOf("img_logo", "user_email", "rb_flavor", "logo_image", "profile_img")
+
+        ids.forEach { id ->
+            assertEquals(id, FuzzyAttributeParser.parse("id:$id", "ImageView")["android:id"])
+        }
+    }
+
+    @Test
     fun `Given_clean_and_noisy_duplicate_dimensions_When_parsed_Then_clean_dimension_is_preserved`() {
         val result = FuzzyAttributeParser.parse(
             "layoutwidth:150dp | layoutwidth:15Ddp",

--- a/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/xml/LayoutRendererTest.kt
+++ b/sketch-to-ui-plugin/src/test/java/org/appdevforall/codeonthego/computervision/domain/xml/LayoutRendererTest.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 class LayoutRendererTest {
 
     @Test
-    fun `checkbox group uses canonical ids when OCR annotation id is noisy`() {
+    fun `Given_checkbox_group_with_noisy_id_annotation_When_rendered_Then_canonical_child_ids_are_used`() {
         val first = checkboxBox(y = 0, text = "Option A")
         val second = checkboxBox(y = 20, text = "Option B", checked = true)
         val context = XmlContext()
@@ -33,7 +33,7 @@ class LayoutRendererTest {
     }
 
     @Test
-    fun `checkbox group noisy textColor annotation emits valid textColor without losing option labels`() {
+    fun `Given_checkbox_group_with_noisy_text_color_annotation_When_rendered_Then_valid_text_color_and_option_labels_are_preserved`() {
         val first = checkboxBox(y = 0, text = "Option 1", checked = true)
         val second = checkboxBox(y = 20, text = "Option 2")
         val third = checkboxBox(y = 40, text = "Option 3", checked = true)
@@ -62,7 +62,7 @@ class LayoutRendererTest {
     }
 
     @Test
-    fun `radio group ignores group style ids on child radios`() {
+    fun `Given_radio_group_with_group_style_id_annotation_When_rendered_Then_child_radios_ignore_group_id`() {
         val first = radioBox(y = 0, text = "choice A")
         val second = radioBox(y = 20, text = "choice B", checked = true)
         val context = XmlContext()
@@ -78,13 +78,13 @@ class LayoutRendererTest {
 
         val xml = context.toString()
 
-        assertTrue(xml.contains("""android:id="@+id/radio_button_unchecked_0""""))
-        assertTrue(xml.contains("""android:id="@+id/radio_button_checked_0""""))
+        assertTrue(xml.contains("""android:id="@+id/radio_button_0""""))
+        assertTrue(xml.contains("""android:id="@+id/radio_button_1""""))
         assertTrue(!xml.contains("""android:id="@+id/rb_group_1""""))
     }
 
     @Test
-    fun `radio group ignores group style ids even when parser leaks trailing tokens`() {
+    fun `Given_radio_group_with_leaked_group_id_tokens_When_rendered_Then_child_radios_ignore_group_id`() {
         val first = radioBox(y = 0, text = "choice A")
         val second = radioBox(y = 20, text = "choice B", checked = true)
         val context = XmlContext()
@@ -100,12 +100,72 @@ class LayoutRendererTest {
 
         val xml = context.toString()
 
-        assertTrue(xml.contains("""android:id="@+id/radio_button_unchecked_0""""))
+        assertTrue(xml.contains("""android:id="@+id/radio_button_0""""))
         assertTrue(!xml.contains("""android:id="@+id/rb_group_1_text_site_16sp""""))
     }
 
     @Test
-    fun `switch and image metadata render recovered xml without tag text`() {
+    fun `Given_radio_group_with_structural_and_style_attrs_When_rendered_Then_structural_attrs_stay_on_group_and_style_attrs_apply_to_children`() {
+        val first = radioBox(y = 0, text = "Small")
+        val second = radioBox(y = 20, text = "Medium", checked = true)
+        val third = radioBox(y = 40, text = "Large")
+        val context = XmlContext()
+
+        val renderer = LayoutRenderer(
+            context = context,
+            annotations = identityAnnotationMap(
+                first to "id: rb_group_1 | width: 80dp | height: 50dp | textSize: 12sp | textColor: blue"
+            )
+        )
+
+        renderer.render(LayoutItem.RadioGroup(listOf(first, second, third), "vertical"))
+
+        val xml = context.toString()
+        val radioGroup = xmlBlock(xml, "RadioGroup")
+        val radioButtons = xmlBlocks(xml, "RadioButton")
+
+        assertTrue(radioGroup.contains("""android:layout_width="80dp""""))
+        assertTrue(radioGroup.contains("""android:layout_height="50dp""""))
+        assertEquals(3, radioButtons.size)
+
+        radioButtons.forEach { button ->
+            assertTrue(button.contains("""android:layout_width="wrap_content""""))
+            assertTrue(button.contains("""android:layout_height="wrap_content""""))
+            assertFalse(button.contains("""android:layout_width="80dp""""))
+            assertFalse(button.contains("""android:layout_height="50dp""""))
+            assertFalse(button.contains("""android:id="@+id/rb_group_1""""))
+            assertTrue(button.contains("""android:textSize="12sp""""))
+            assertTrue(button.contains("""android:textColor="#0000FF""""))
+        }
+    }
+
+    @Test
+    fun `Given_radio_button_with_explicit_child_size_When_rendered_inside_radio_group_Then_child_size_is_preserved`() {
+        val first = radioBox(y = 0, text = "Small")
+        val second = radioBox(y = 20, text = "Medium", checked = true)
+        val context = XmlContext()
+
+        val renderer = LayoutRenderer(
+            context = context,
+            annotations = identityAnnotationMap(
+                first to "id: rb_group_1 | width: 80dp | height: 50dp | textSize: 12sp | textColor: blue",
+                second to "width: 120dp | height: 32dp"
+            )
+        )
+
+        renderer.render(LayoutItem.RadioGroup(listOf(first, second), "vertical"))
+
+        val xml = context.toString()
+        val radioButtons = xmlBlocks(xml, "RadioButton")
+
+        assertTrue(radioButtons[0].contains("""android:layout_width="wrap_content""""))
+        assertTrue(radioButtons[0].contains("""android:layout_height="wrap_content""""))
+        assertTrue(radioButtons[1].contains("""android:layout_width="120dp""""))
+        assertTrue(radioButtons[1].contains("""android:layout_height="32dp""""))
+    }
+
+    @Test
+    fun `Given_switch_and_image_with_noisy_metadata_When_rendered_Then_recovered_xml_excludes_tag_text`() {
         val switch = box("switch_off", "P-1 P-1", x = 0, y = 0, w = 80, h = 40)
         val image = box("image_placeholder", "", x = 0, y = 60, w = 200, h = 100)
         val context = XmlContext()
@@ -136,7 +196,7 @@ class LayoutRendererTest {
     }
 
     @Test
-    fun `real switch labels remain visible`() {
+    fun `Given_switch_with_real_label_When_rendered_Then_label_remains_visible`() {
         val switch = box("switch_off", "WiFi", x = 0, y = 0, w = 80, h = 40)
         val context = XmlContext()
 
@@ -177,7 +237,7 @@ class LayoutRendererTest {
     }
 
     @Test
-    fun `Given_non_password_EditText_with_explicit_text_When_rendered_Then_text_is_included`() {
+    fun `Given_non_password_edit_text_with_explicit_text_When_rendered_Then_text_is_included`() {
         val input = box("text_entry_box", "", x = 0, y = 0, w = 200, h = 52)
         val context = XmlContext()
 
@@ -199,7 +259,7 @@ class LayoutRendererTest {
     }
 
     @Test
-    fun `Given_password_EditText_with_metadata_text_When_rendered_Then_metadata_text_is_excluded`() {
+    fun `Given_password_edit_text_with_metadata_text_When_rendered_Then_metadata_text_is_excluded`() {
         val input = box("text_entry_box", "Password", x = 0, y = 0, w = 200, h = 52)
         val context = XmlContext()
 
@@ -273,7 +333,7 @@ class LayoutRendererTest {
     }
 
     @Test
-    fun `image without recoverable metadata keeps fallback id`() {
+    fun `Given_image_without_recoverable_metadata_When_rendered_Then_fallback_id_is_used`() {
         val image = box("image_placeholder", "", x = 0, y = 0, w = 200, h = 100)
         val context = XmlContext()
 
@@ -292,7 +352,7 @@ class LayoutRendererTest {
     }
 
     @Test
-    fun `spinner annotation id is used for widget id and generated entries array`() {
+    fun `Given_spinner_with_annotation_id_and_entries_When_rendered_Then_widget_id_and_entries_array_are_generated`() {
         val dropdown = box("dropdown", "StateofResidence", x = 0, y = 0, w = 260, h = 52)
         val context = XmlContext()
 
@@ -393,5 +453,17 @@ class LayoutRendererTest {
             y == other.y &&
             w == other.w &&
             h == other.h
+    }
+
+    private fun xmlBlock(xml: String, tag: String): String {
+        return xmlBlocks(xml, tag).single()
+    }
+
+    private fun xmlBlocks(xml: String, tag: String): List<String> {
+        val escapedTag = Regex.escape(tag)
+        return Regex("""<$escapedTag\b.*?(?:/>|</$escapedTag>)""", RegexOption.DOT_MATCHES_ALL)
+            .findAll(xml)
+            .map { it.value }
+            .toList()
     }
 }


### PR DESCRIPTION
## Description

Fixes duplicated `img_` prefixes in generated `ImageView` IDs when OCR metadata already provides a valid image ID, such as `img_logo`. The parser now preserves the intended metadata value and avoids generating inconsistent IDs like `img_img_logo`.

## Details

Adds coverage for noisy ImageView metadata, explicit ImageView IDs, RadioGroup child attribute handling, CheckboxGroup ID recovery, and password EditText metadata recovery. Also reuses centralized constants and patterns where applicable to keep XML generation and parser recovery consistent.

### Before

https://github.com/user-attachments/assets/fa27978c-0746-4a7c-8fa8-a26a47e4187f

### After

https://github.com/user-attachments/assets/b8980656-928a-423e-937d-53cfc87216cb

### Tested sketch

<img width="758" height="787" alt="Screenshot 2026-05-23 at 10 11 55 AM" src="https://github.com/user-attachments/assets/f6dbfafc-4c03-4416-80b8-a1899fd64c3e" />

## Ticket

[ADFA-4299](https://appdevforall.atlassian.net/browse/ADFA-4299)

## Observation

The main issue was caused before XML writing, during OCR metadata parsing and ID cleanup. The XML writer now receives a clean `img_logo` ID instead of a duplicated `img_img_logo` value.

[ADFA-4299]: https://appdevforall.atlassian.net/browse/ADFA-4299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ