### PR TITLE
Prototype Claude agent setup for this repo, using shared skills and adding in definition of done in REVIEW.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "common-agent-setup": {
+      "source": {
+        "source": "github",
+        "repo": "appdevforall/common-agent-setup"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "adfa-agent@common-agent-setup": true
+  }
+}

--- a/.claude/skills/android-qa-plugins/SKILL.md
+++ b/.claude/skills/android-qa-plugins/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: android-qa-plugins
+user-invocable: true
+description: Use when running the android-qa skill, or when using mobile-mcp or adb, to test a CoGo (CodeOnTheGo) plugin in this repo. Supplies the CoGo-specific device-QA details — plugin install flow, UI navigation, plugin-load failure modes, and CoGo emulator bootstrap — on top of the generic android-qa methodology.
+---
+
+# android-qa-plugins
+
+Load alongside the generic `android-qa` skill; this adds the CoGo-plugin specifics — install flow, IDE navigation, plugin-load failure modes, and CoGo emulator bootstrap.
+
+A **CoGo plugin** is a `.cgp`-packaged add-on installed into the CoGo IDE through its Plugin Manager. Plugin APKs load via a `DexClassLoader`, which is the root cause of several of the failure modes below.
+
+## Clean state for CoGo plugins / the CoGo IDE
+
+⚠️ The generic `android-qa` skill's destructive-reset safety guard applies here too — `pm clear com.itsaky.androidide` wipes the user's projects, so prefer uninstalling just the plugin.
+
+| Target | Clean state means |
+|---|---|
+| **CoGo plugin** | Plugin NOT installed. The flow exercises install + restart + first-time activation. If already installed: uninstall via Plugin Manager + restart, *then* start recording. |
+| **CoGo IDE itself** | App data cleared (`pm clear com.itsaky.androidide`) or a fresh APK install. Exercises onboarding, permission grants, project creation. |
+
+## Installing a `.cgp`
+
+1. Drawer → IDE preferences → Plugin Manager → **+** (bottom-right FAB ~956, 2081).
+2. File picker → hamburger → **Downloads** (newly-pushed `.cgp` files don't appear under "Recent" until interacted with, so go to `/sdcard/Download/` directly) → tap the `.cgp`.
+3. **Install Plugin** dialog → **Install**.
+4. **Restart required** → **Restart now**.
+5. After restart the plugin shows in Plugin Manager with status **Enabled**.
+
+**Build plugins as a release variant for install.** Production CoGo (Android 16) silently drops trailing manifest meta-data entries when parsing a debug `.cgp` via the legacy `getPackageArchiveInfo` API, which trips a debug-only icon-asset validator. Build with `./gradlew assemblePlugin` (release) — the validator only fires when `ApplicationInfo.FLAG_DEBUGGABLE` is set, which release builds clear.
+
+## CoGo UI navigation cheat sheet
+
+Use when the target is the CoGo IDE or a CoGo plugin. Any coordinates below are illustrative — confirm with `mobile_list_elements_on_screen` on your device.
+
+**Hamburger drawer (`com.itsaky.androidide:id/navigation`):**
+| Drawer entry | Approx center | Notes |
+|---|---|---|
+| File tree | 79, 194 | Default open state |
+| Build variants | 79, 352 | |
+| Terminal | 79, 510 | |
+| IDE preferences | 79, 668 | **Path to Plugin Manager** |
+| Close this project | 79, 826 | |
+| Help | 79, 984 | |
+
+Dismiss the drawer without navigating via the "Close project menu" button (top-right ~934, 171). BACK works too but may nest.
+
+**IDE preferences screen** (after the drawer entry above): Plugin Manager is the 6th item, around `(204, 1414)`. The list also has General / Editor / Build & Run / Termux / Git / About / Developer Options.
+
+**Bottom sheet — plugin tabs live at the far right:**
+1. Collapsed by default at y ≈ 1924–2205.
+2. Expand: `mobile_swipe_on_screen direction=up x=540 y=2000 distance=1500`.
+3. Built-in tabs (left→right): Build Output, App Logs, IDE Logs, Diagnostics, Search Results, Debugger, Git. Plugin tabs appear after them at the far right.
+4. Scroll the tab row right to reveal plugin tabs: `direction=left x=700 y=560 distance=1400` (expanded state).
+5. Tap the plugin tab to switch the ViewPager to that plugin's Fragment.
+
+**Plugin view IDs** are namespaced under the plugin's package, e.g. `com.codeonthego.xkcdrandom:id/xkcd_image`. Treat `mobile_list_elements_on_screen` as authoritative — coordinate hints from past sessions can shift across CoGo restarts.
+
+**Three-tier in-app tooltip (per plugin)** — CoGo's per-plugin help:
+1. **Long-press** the plugin's bottom-sheet **tab title** (not the content) for ~2s → tier-1 popup + a "+ See more" link near `(540, 1294)`.
+2. "See more" → tier-2 popup with a "Learn more" link around `(300, 1170)`.
+3. "Learn more" → opens a full-screen browser to `http://localhost:6174/plugin/<plugin-id>/<uri>`.
+
+**State persists across restart:** `am force-stop com.itsaky.androidide` + relaunch via `monkey -c LAUNCHER 1` returns to the last open project's EditorActivity. The bottom sheet collapses on restart but the last-active plugin tab stays selected once reopened.
+
+## Plugin-load failure modes (logcat)
+
+Plugin APKs load via a `DexClassLoader`, so the host app's classloader has no visibility into plugin classes. Grep logcat (per the generic skill's "Read logcat" pattern) for:
+
+- `ActivityNotFoundException: Unable to find explicit activity class {<plugin>/.X}` — plugin Activities don't register via the plugin's `DexClassLoader`. Don't `startActivity()` a plugin Activity directly; route through Fragments or recipes.
+- `Resources$NotFoundException` during Fragment inflation — the plugin Fragment isn't using `PluginFragmentHelper.getPluginInflater(...)`.
+- `InflateException` on heavy views (MapView, custom GL) — a historical risk on low-end devices.
+
+If a plugin bundles native libraries and they fail to load, confirm they were extracted at install time:
+```bash
+adb -s $DEVICE_SERIAL shell run-as com.itsaky.androidide ls app_plugin_native_libs/
+```
+Absence of `<plugin-id>/` there means the `.so` files didn't extract — a strong signal the plugin's `useLegacyPackaging` / `native.code` permission setup is wrong.
+
+## CoGo emulator bootstrap
+
+The generic skill covers bringing up the AVD (launch, wait for boot, data-partition size, freeing RAM). When the target is **CoGo** on an emulator (vs the physical A56), you additionally must:
+
+1. Build CoGo locally (e.g. `./gradlew :app:assembleV8Debug` in the team build env).
+2. Install the APK: `adb install -r app/build/outputs/apk/v8/debug/CodeOnTheGo-v8-debug-*.apk`.
+3. Push the assets zip: `adb push app/build/outputs/assets/assets-arm64-v8a.zip /sdcard/Download/`.
+4. Pre-grant the 4 onboarding permissions:
+   ```bash
+   adb shell pm grant com.itsaky.androidide android.permission.POST_NOTIFICATIONS
+   adb shell appops set com.itsaky.androidide MANAGE_EXTERNAL_STORAGE allow
+   adb shell appops set com.itsaky.androidide REQUEST_INSTALL_PACKAGES allow
+   adb shell appops set com.itsaky.androidide SYSTEM_ALERT_WINDOW allow
+   ```
+5. Drive the onboarding (intro card → privacy dialog → permissions screen → finish installation).
+
+CoGo extracts the Termux bootstrap from the assets zip on first launch (~30–60 s). The AVD needs `disk.dataPartition.size=16G` (the 6 GB default fails CoGo's bootstrap) — set this when bringing up the emulator per the generic skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,22 +1,32 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for AI agents (and developers) working in this repository. Auto-loaded into every session here.
 
-## Repository purpose
+## What this repo is
 
-Reference plugins for [CodeOnTheGo](https://github.com/appdevforall/CodeOnTheGo) (CoGo / CotG). Each top-level folder (`Beepy/`, `apk-viewer/`, `markdown-preview/`, `keystore-generator/`, `snippets/`, `random-xkcd/`, `icons-repository/`, `ndk-installer-plugin/`, `sketch-to-ui-plugin/`) is an independent Gradle project that builds a `.cgp` plugin installable via the CoGo Plugin Manager. They're held together only by the shared `libs/` jars at the repo root.
+A collection of **reference plugins** for [CodeOnTheGo](https://github.com/appdevforall/CodeOnTheGo) (CoGo) — an on-device Android IDE. Each top-level folder (`Beepy/`, `apk-viewer/`, `markdown-preview/`, `keystore-generator/`, `random-xkcd/`, `ndk-installer-plugin/`, `sketch-to-ui-plugin/`, …) is an **independent Gradle project** that builds a `.cgp` file — the packaged plugin format CoGo installs via its Plugin Manager. The only thing tying the folders together is the shared `libs/` jars at the repo root (see Architecture).
 
-## Common commands
+These are **teaching examples** for future plugin authors. Keep them clear, minimal, and well-commented — not architecturally elaborate.
+
+## Shared workflow (the `adfa-agent` plugin)
+
+This repo is a client of the [`common-agent-setup`](https://github.com/appdevforall/common-agent-setup) marketplace. `.claude/settings.json` enables the **`adfa-agent`** plugin, which supplies the shared workflow skills: `plan-for-done`, `check-done`, `prepare-pr`, `android-qa`, `ux-review`, `retro`. If they're missing, run `/plugin install adfa-agent`.
+
+- **Plan first** (plan mode). `plan-for-done` checks the plan against the definition of done before you build.
+- **`check-done`**** gates completion.** It (and `plan-for-done`) reads **this repo's ****`REVIEW.md`** — the complete definition of done (the plugin-specific submission gates), nothing from the plugin itself. Don't call a plugin done until `check-done` is green.
+- **Conventions** (layering, dependency direction, SRP checks) live in this repo's `architecture.md` (at the repo root). Not restated here.
+
+## Build commands
 
 Build one plugin:
 
 ```sh
-cd Beepy   # or any plugin folder
-./gradlew assemblePlugin           # release .cgp -> build/plugin/<pluginName>.cgp
-./gradlew assemblePluginDebug      # debug variant
+cd Beepy                          # or any plugin folder
+./gradlew assemblePlugin          # release .cgp -> build/plugin/<pluginName>.cgp
+./gradlew assemblePluginDebug     # debug variant
 ```
 
-Build every plugin from scratch (after rebuilding libs):
+Rebuild the shared `libs/` jars and then every plugin from scratch:
 
 ```sh
 ./scripts/update-libs.sh                          # default: github.com/appdevforall/CodeOnTheGo@stage
@@ -24,31 +34,44 @@ Build every plugin from scratch (after rebuilding libs):
 ./scripts/update-libs.sh --local ../CodeOnTheGo   # use an existing checkout instead of cloning
 ```
 
-The script clones CoGo into `.cache/CodeOnTheGo/` on first run, rebuilds both jars, copies them into `libs/`, then runs `assemblePlugin` for every example. It auto-detects examples by scanning for `build.gradle.kts` files that apply `com.itsaky.androidide.plugins.build`.
+The script clones CoGo into `.cache/CodeOnTheGo/` on first run, rebuilds both jars, copies them into `libs/`, then runs `assemblePlugin` for every example (auto-detected by scanning for `build.gradle.kts` files that apply `com.itsaky.androidide.plugins.build`).
 
-`local.properties` must contain `sdk.dir=...`. The committed `local.properties` at the repo root is harmless leftover; each plugin needs its own.
+Each plugin needs a `local.properties` with `sdk.dir=...` (path to your Android SDK). The committed root `local.properties` is harmless leftover.
+
+> **Always ****`clean`**** before re-staging a debug build.** Re-running `assemblePluginDebug` without `clean` produces a stub `.cgp` — a known plugin-builder bug where the first run deletes the source APK. Use `./gradlew clean assemblePluginDebug`.
 
 ## Architecture
 
 ### `libs/` is the load-bearing piece
 
-Every plugin depends on two jars in the repo-root `libs/`:
+Every plugin depends on two jars in the repo-root `libs/`, referenced via `../libs/*.jar`:
 
-- **`plugin-api.jar`** — the IDE-side API surface (`IPlugin`, `PluginContext`, `BuildStatusListener`, `IdeBuildService`, etc.). Each plugin uses it as `compileOnly` (provided by the IDE at runtime) AND as `buildscript classpath` so the Gradle plugin can resolve symbols at configuration time.
-- **`gradle-plugin.jar`** — the Gradle plugin with id `com.itsaky.androidide.plugins.build`, applied by every plugin. It's the output of CoGo's `plugin-api/plugin-builder/` module (separate from CoGo's `gradle-plugin/` module, which is unrelated despite the name). It packages the compiled Android library into a `.cgp`.
+- **`plugin-api.jar`** — the IDE-side API (`IPlugin`, `PluginContext`, `BuildStatusListener`, `IdeBuildService`, …). Each plugin uses it as **`compileOnly`** (compiled against, but not bundled — the IDE provides it at runtime) AND puts it on the **buildscript classpath** so the Gradle plugin can resolve its symbols at configuration time.
+  - **Its ABI must match the installed host.** "ABI" here means the exact class/method shapes the host exposes. A plugin built against a stale `plugin-api.jar` whose shapes differ from the running host throws `NoSuchMethodError` / `LinkageError` at startup — and the host's per-plugin `catch` does **not** catch these, so it crashes the IDE. Refresh the jar (via the script) whenever the host API changes.
+- **`gradle-plugin.jar`** — provides the Gradle plugin id `com.itsaky.androidide.plugins.build` that every plugin applies. It is the output of CoGo's `plugin-api/plugin-builder/` module and packages the compiled Android library into a `.cgp`.
 
-Both jars are referenced via `../libs/*.jar`. **A plugin folder is not standalone in isolation** — copy `libs/` along if you move one elsewhere. When CoGo's API changes, refresh via the script above or the **Update libs from CodeOnTheGo** GitHub Action (which also commits the refreshed jars, cuts a release, and deploys `.cgp` files to the website).
+**A plugin folder is not standalone** — copy `libs/` along if you move one. Refresh the jars via the script above, or via the **Update libs from CodeOnTheGo** GitHub Action (which also commits the jars, cuts a release, and deploys `.cgp` files to the website).
 
-### Plugin shape
+### Plugin module shape
 
-A plugin is an Android *application* module (despite installing as a library) with:
+A plugin is an Android **application** module (even though it installs as a library) with:
 
-1. **`build.gradle.kts`** applies `com.android.application`, `org.jetbrains.kotlin.android`, and `com.itsaky.androidide.plugins.build`. Configures `pluginBuilder { pluginName = "..." }`. Uses `compileOnly(files("../libs/plugin-api.jar"))` — never `implementation`.
-2. **`settings.gradle.kts`** declares the two jars on the buildscript classpath plus AGP and Kotlin.
-3. **`src/main/AndroidManifest.xml`** declares plugin identity as `<meta-data>` entries on `<application>`: `plugin.id`, `plugin.name`, `plugin.version` (resolved from `${pluginVersion}`), `plugin.description`, `plugin.author`, `plugin.main_class`, `plugin.min_ide_version`, and optional `plugin.permissions`.
-4. **Main class** implements `com.itsaky.androidide.plugins.IPlugin`. Lifecycle: `initialize(PluginContext) → activate() → deactivate() → dispose()`. Services are obtained via `context.services.get(SomeService::class.java)` (e.g. `IdeBuildService` for build hooks). Android `Context` is `context.androidContext`.
+1. **`build.gradle.kts`** — applies `com.android.application`, `org.jetbrains.kotlin.android`, and `com.itsaky.androidide.plugins.build`. Configures `pluginBuilder { pluginName = "..." }`. Uses `compileOnly(files("../libs/plugin-api.jar"))` — never `implementation`.
+2. **`settings.gradle.kts`** — declares the two jars on the buildscript classpath, plus AGP and Kotlin.
+3. **`src/main/AndroidManifest.xml`** — declares plugin identity as `<meta-data>` entries on `<application>`: `plugin.id`, `plugin.name`, `plugin.version` (from `${pluginVersion}`), `plugin.description`, `plugin.author`, `plugin.main_class`, `plugin.min_ide_version`, and optional `plugin.permissions`.
+4. **Main class** — implements `com.itsaky.androidide.plugins.IPlugin`. Lifecycle: `initialize(PluginContext) → activate() → deactivate() → dispose()`. Access IDE services via `context.services.get(SomeService::class.java)`; the Android `Context` is `context.androidContext`.
+  - **In ****`dispose()`****, release everything you acquired** — threads, listeners, sockets — and clear any static references to IDE objects. Leaks that survive an enable/disable cycle are a submission-rubric reject.
 
-Available permission strings (declared comma-separated in `plugin.permissions`): `filesystem.read`, `filesystem.write`, `network.access`, `system.commands`, `ide.settings`, `project.structure`.
+**Permission strings** (comma-separated in `plugin.permissions`): `filesystem.read`, `filesystem.write`, `network.access`, `native.code`, `system.commands`, `ide.settings`, `ide.environment.write`, `project.structure`. Request only what you use — over-requesting is a rubric reject.
+
+### Silent-failure gotchas
+
+Each of these fails with **no logcat error** — the plugin simply goes missing from Plugin Manager after restart. Symptom is always the same; the fix differs:
+
+- **Release ****`.cgp`**** is unsigned → host rejects it.** Wire a `signingConfig` (e.g. a `releaseDebugKey` pointing at `~/.android/debug.keystore`).
+- **Debug builds trip an icon-asset validator** that release skips. Ship `assets/icon_day.png` + `assets/icon_night.png` (96×96 RGBA) AND declare them as `plugin.icon_day` / `plugin.icon_night` meta-data.
+- **Bundling native ****`.so`**** libraries** requires both `plugin.permissions=native.code` AND `android.packaging.jniLibs.useLegacyPackaging = true` (so the `.so` extracts to disk at install time instead of staying compressed in the APK).
+- **Plugin Fragments crash when Android restores them by class name** (e.g. on rotation), because the plugin's classes load via `DexClassLoader` — a separate classloader the host's default `FragmentFactory` can't see. Fix: install a plugin-classloader-aware `FragmentFactory` on every host `FragmentManager` that hosts a plugin Fragment. Canonical pattern: `learnings.md` in the agent docs.
 
 ### Convention: AAR metadata checks are disabled
 
@@ -61,19 +84,20 @@ tasks.matching {
 }.configureEach { enabled = false }
 ```
 
-This is intentional — the `application`-as-library packaging trips those checks. Keep it.
+This is intentional. AAR metadata checks validate library-module packaging; the `application`-as-library packaging trick used here trips them. Keep the block.
 
 ### Asset downloads (rare)
 
-Some plugins (currently `ndk-installer-plugin`) register a `downloadAssets` task that fetches a tarball at build time with MD5 verification. `scripts/update-libs.sh` runs it automatically before `assemblePlugin` when the build file references it.
+Some plugins (currently `ndk-installer-plugin`) register a `downloadAssets` task that fetches a tarball at build time and verifies it by MD5. `scripts/update-libs.sh` runs that task before `assemblePlugin` when the build file references it.
 
 ## Adding a new plugin
 
-1. Copy `random-xkcd/` — it's the canonical starting template (small but complete, includes the in-IDE help HTML pattern that submissions are expected to follow).
-2. Update `settings.gradle.kts` `rootProject.name`, `build.gradle.kts` `pluginBuilder { pluginName }` + `android { namespace, applicationId }`, and `src/main/AndroidManifest.xml` (`plugin.id`, `plugin.name`, `plugin.main_class`).
-3. Add a row to the README's Examples table.
-4. If your plugin should ship via the website, add it to the `MAP` array in `.github/workflows/build-plugins.yml` and `.github/workflows/update-libs.yml` so the filename mapping picks it up.
+1. **Copy ****`random-xkcd/`** — the canonical starting template (small but complete; includes the in-IDE help-HTML pattern submissions are expected to follow).
+2. **Update identity** in `settings.gradle.kts` (`rootProject.name`), `build.gradle.kts` (`pluginBuilder { pluginName }` + `android { namespace, applicationId }`), and `src/main/AndroidManifest.xml` (`plugin.id`, `plugin.name`, `plugin.main_class`). Use the `org.appdevforall.<plugin>` namespace.
+3. **Add a row** to the README's Examples table.
+4. **To ship via the website**, add it to the `MAP` array in `.github/workflows/build-plugins.yml` and `.github/workflows/update-libs.yml`.
+5. **Before calling it done**, walk `REVIEW.md` and run the `cogo-plugin-review` skill (below).
 
 ## Plugin review skill
 
-`.claude/skills/plugin-review/` contains the `cogo-plugin-review` skill — invoke via `/plugin-review` or `/cotg-plugin-review` when the user asks to review, audit, or check a CoGo plugin for submission readiness. It builds, audits security, and scores against the submission rubric.
+`.claude/skills/plugin-review/` is the `cogo-plugin-review` skill — invoke via `/plugin-review` (or `/cotg-plugin-review`). It builds the plugin, audits its security, and scores it against the submission rubric (the `REVIEW.md` §9 gate).

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,220 @@
+# Definition of Done — plugin-examples
+
+This is the complete definition of done for this repo. The `plan-for-done` and `check-done`
+skills read **this file** — there is no separate base. Everything you must prove before
+declaring work done lives here.
+
+**The bar:** before declaring work done / ready for review (or opening a PR), prove each
+applicable gate is met **with evidence**, or flag it with a written reason. "Builds and the happy
+path works" is necessary, never sufficient. Skip a gate only when it genuinely doesn't apply —
+never because it's untested.
+
+The file has two parts:
+
+- **Core gates** apply to *every* change.
+- **Plugin gates** add what a CoGo plugin specifically needs. A plugin builds into a **`.cgp`**
+  (a CoGo plugin package — a signed Android APK the IDE loads at runtime via `DexClassLoader`),
+  so it can be fully built, installed, and pass happy-path QA while still shipping placeholder
+  assets, half-wired features, stale docs, or manifest mistakes — none of which crash. The plugin
+  gates catch that class of defect.
+
+Apply the plugin gates at **design time** (pick conventional approaches and coherent names up
+front) and again at **completion** (run the sweep at the end; report what it found, even
+"nothing"). Treat any unchecked box as fixed or explicitly flagged to the reviewer with a reason.
+
+---
+
+# Core gates (every change)
+
+1. **Builds clean.** Report the actual build result, not "should compile." State the build target
+   and that it's green.
+2. **Tests — logic AND behavior.** Tests catch regressions a green build can't.
+   - Logic/unit tests for the change. **≥90% line *and* branch coverage on non-UI code** (domain /
+     data / logic), verified with a real coverage report (e.g. JaCoCo), not by eye. UI (Fragments,
+     Activities, GL surfaces) is exempt — it's covered by on-device QA (gate 6). Rare
+     unreachable-defensive branches may be skipped *with a noted reason*.
+   - **Coverage is a floor, not the goal.** Each test must *fail if the code were wrong* (the
+     mutation-test mindset): assert real behavior, not just "didn't throw"; test the contract, not
+     internals; cover meaningful edge / boundary / error cases; stay deterministic and isolated. A
+     line executed with no assertion that catches a plausible bug is coverage theater.
+   - **Never suppress coverage to hit the number** (no exclude config, `@Suppress`, or dropping a
+     real class from the denominator). If something is hard to test, refactor it for testability.
+3. **No file I/O on the main thread.** Blocking I/O on the UI thread freezes the app. Run every
+   file read / write / `mkdirs` / `delete` / `listFiles` / stream off the main thread (e.g. on an
+   I/O dispatcher). Make the guarantee **structural** — a data-layer function that wraps its own
+   I/O internally — rather than trusting every caller to remember.
+4. **Structure / single-responsibility / layering.** Sound structure keeps a change's blast radius
+   small. Walk the coupling-&-cohesion audit and SRP checks in `architecture.md`: UI-vs-logic
+   separation, dependencies flowing toward the domain, no god-objects, no domain types stranded in
+   UI packages. Apply at design time (`plan-for-done`) and again at review time.
+5. **Code review pass.** Reviewers are the last line before shipping; run a substantive
+   code-review pass and fix blockers in-branch.
+6. **On-device QA + UX review for any UI surface.** Code-only tests can't see runtime UX bugs. Any
+   change that adds or alters a user-visible surface gets an `android-qa` walk on a real device
+   against a `test-cases.md` flow doc, with a captioned recording. Cover the full flow — list every
+   test-case ID rather than a range (a range hides omissions), and confirm by frame, not just by
+   caption (a caption asserts intent; only a frame proves capture). Once the flows pass clean, run
+   a `ux-review` on the working end-to-end flow: **critical findings block ship** (fix before the
+   PR); important findings go in the PR followups.
+7. **Docs updated.** Stale docs mislead the next reader. Record non-obvious decisions and durable
+   gotchas in the repo's decisions / learnings docs, and update any README / help / roster the
+   change makes stale.
+
+---
+
+# Plugin gates
+
+## 1. Naming coherence
+
+A plugin's name appears in ~8 places; they must tell one story, or the plugin looks half-renamed.
+
+- [ ] **Module folder** uses the lowercase convention (e.g. `apk-viewer`).
+- [ ] **`rootProject.name`** (settings.gradle.kts) matches the folder.
+- [ ] **`namespace` + `applicationId`** (build.gradle.kts) are `org.appdevforall.<plugin>` — the
+  repo standard. (Some older plugins use `com.example.*` / `com.codeonthego.*`; don't add to that
+  inconsistency.)
+- [ ] **`plugin.id`** (manifest) matches the namespace.
+- [ ] **`plugin.main_class`** points at the real main class in its real package.
+- [ ] **Main class name** matches the plugin (no leftover name from a copied template).
+- [ ] **`.cgp` pluginName** (`pluginBuilder { pluginName }` in build.gradle.kts) is coherent.
+- [ ] **User-facing display names agree** — `plugin.name`, `<application android:label>`, `app_name`,
+  the tab title, in-UI headings — one canonical name (document any deliberate exception).
+- [ ] **Resource-id prefixes, tooltip tags, test env vars** carry no old name.
+- [ ] A `grep -rni "<oldname>"` over `src`, `build.gradle.kts`, and the manifest returns nothing
+  unexpected.
+
+## 2. No placeholder or carried-over assets
+
+Copied template content shipped as-is makes a plugin look unfinished.
+
+- [ ] **Icons** (`icon_day.png` / `icon_night.png`) are the plugin's own — `md5sum` differs from the
+  `random-xkcd` reference plugin's (the canonical copy-from template).
+- [ ] Icons match the shared style (monochrome glyph, transparent background) and render correctly on
+  both light and dark surfaces.
+- [ ] No strings, layouts, or sample data copied from a template still name the wrong plugin/feature.
+
+## 3. Feature complete — nothing half-wired
+
+A partially built feature that doesn't crash still misleads the user.
+
+- [ ] **Every acceptance criterion is implemented** — re-read the ticket; confirm the full set, not
+  just the demo path. Intentional descopes are written down (ticket + `decisions.md`), never a
+  silent omission.
+- [ ] **Each feature is end-to-end** (data → logic → UI, happy path *and* edges) or absent — nothing
+  partially built ships as if complete.
+- [ ] **Every UI control does something** — no button/toggle/menu item wired to a stub or no-op.
+- [ ] Deferred features are hidden or clearly marked unavailable, and documented in `decisions.md`.
+- [ ] Grep for stub signatures (`TODO` / `FIXME` / `not yet` / `return emptyList()` on a feature
+  path) — each is intentional + documented, or removed.
+
+## 4. No vestigial scaffolding
+
+Dead code from removed or abandoned features confuses the next author.
+
+- [ ] Removed features leave nothing behind: no orphan enum values, unused string resources, dead
+  branches, or files for a feature that no longer exists.
+- [ ] Comments describe the current state, not a past one.
+- [ ] **No dead parallel architecture** — no DI module / ViewModel / abstraction the actual UI
+  bypasses. Pick one wiring and delete the other.
+
+## 5. Docs match shipped reality
+
+Docs are how a user decides whether to install; they must be accurate.
+
+- [ ] README and any tutorial describe what the code actually does — correct file formats, correct
+  counts, no aspirational claims stated as fact.
+- [ ] **In-IDE HTML help present** — a top-level `<plugin>.html` plus the tiered help the reference
+  plugins ship (HTML, not raw Markdown). Submission rubric §6.6.
+- [ ] Tooltips and other user-facing help name the plugin correctly and list real capabilities.
+- [ ] `THIRD_PARTY_LICENSES` is current; new bundled assets (fonts, binaries, models) have
+  attribution.
+- [ ] **Listed in the top-level `README.md` roster** (name + one-line description) — otherwise the
+  plugin is invisible to anyone browsing the repo.
+- [ ] **Registered to deploy** — added to the `MAP` array in both `.github/workflows/build-plugins.yml`
+  and `.github/workflows/update-libs.yml`. CI builds every module, but only those in the `MAP` get a
+  website filename and ship.
+
+## 6. Metadata + conventions (diff against a reference plugin)
+
+The manifest is the plugin's contract with the host; over- or under-declaring breaks load or trust.
+
+- [ ] `plugin.author` is exactly `App Dev For All`.
+- [ ] `plugin.min_ide_version` is justified — the fleet default unless a real host-API dependency
+  requires higher (and sibling plugins on the same API agree). Declare a **supported IDE version
+  range**, not a single point release (rubric §6.1: must run on current stable + the immediately
+  preceding minor).
+- [ ] `plugin.permissions` lists **exactly** what's used — `native.code` iff a `.so` is bundled,
+  `network.access` iff outbound HTTP. The manifest declares every extension, every permission, the
+  IDE version range, and the minimum Android SDK level.
+- [ ] Version, icon meta-data, and sidebar/tab declarations are present and correct.
+- [ ] **Use Pebble/CGT templates for emitted files.** Project templates (the files a plugin scaffolds
+  into a new user project) ship as `.peb` / static assets under `assets/templates/…` rendered by
+  CoGo's CGT framework — not inline Kotlin raw strings (which hide emitted code from lint and carry a
+  string-interpolation footgun). Keep only genuinely dynamic bits programmatic.
+
+## 7. Host-integration correctness (apply only the conditionals that fit)
+
+Each bullet applies **only if your plugin does that thing** — integration traps that pass a build
+and happy-path QA but corrupt state or the user's mental model. Skip a bullet because it doesn't
+apply, never because it's untested.
+
+- [ ] **Edits a file that may be open in an editor?** Update **both** the open editor buffer and disk
+  (prefer the buffer, fall back to disk). A disk-only write leaves stale content or loses unsaved
+  edits.
+- [ ] **Registers a host-service listener / subscription / watch?** Remove and release it in
+  `deactivate()` / `dispose()`, with a use-before-ready guard — otherwise it leaks across
+  enable/disable and double-fires after reload (rubric §6.2: nothing outlives the plugin).
+- [ ] **Exposes an action only valid in a context?** Gate it with `isEnabledProvider` (e.g. greyed
+  unless a relevant file is active) rather than failing with a toast.
+- [ ] **Bundles an ML model?** Ship a host/JVM golden test pinning its output convention (coordinate
+  space, normalization, class order) — a green build won't catch a wrong convention. Model + labels
+  need a `THIRD_PARTY_LICENSES` provenance line.
+- [ ] **Writes generated content into the user's project?** Confirm it lands where the user expects,
+  merges non-destructively (splice into existing files, don't clobber), and is idempotent on re-run.
+- [ ] **Scaffolds a project / app from a template?** The emitted app MUST build **offline, on-device**
+  — using CoGo's bundled offline Maven repo with network repos disabled, verified by actually
+  building on a real device with connectivity off. Keep the template's dependencies inside what the
+  bundled offline repo provides; anything outside is a provisioning gap to resolve up front. This is
+  a separate device check from `assemblePlugin` and the android-qa walk.
+
+## 8. Plugin-API discipline (rubric §6.3–6.5)
+
+- [ ] **Build reproducibility** — the `.cgp` rebuilds from source on a clean machine via the
+  documented command (`./gradlew assemblePlugin`, or `scripts/update-libs.sh` for a full-repo
+  rebuild). No author-machine-only builds.
+- [ ] **No reflection into IDE internals** — only the public `plugin-api` / `lsp/api` surfaces.
+  Reflection against IDE classes is grounds for rejection.
+- [ ] **Native binaries** — any `.so` holds `native.code` and meets the sandbox-bypass tier (§7.3).
+
+## 9. The submission gauntlet — `cogo-plugin-review`
+
+- [ ] **Run the `cogo-plugin-review` skill** (`.claude/skills/plugin-review/`, invoked via
+  `/plugin-review`) — build → security audit → rubric scorecard → report. Required before human
+  review: all rubric clauses Pass, security audit clean, every blocker fixed in-branch (advisory
+  items may defer to PR followups with a written reason). This sits **on top of** the core code-review
+  gate — run both. Land the report at `docs/product/plans/<ticket>/plugin-review-<yyyy-mm-dd>.md`.
+
+---
+
+## The 60-second sweep (paste-ready)
+
+```bash
+P=<plugin-dir>   # e.g. apk-viewer
+OLD=<oldname>    # a prior name, if the plugin was ever renamed (else skip)
+# naming residue:
+grep -rniE "$OLD" "$P/src" "$P/build.gradle.kts" 2>/dev/null | grep -v /build/
+# placeholders / half-finished / stale:
+grep -rniE "TODO|FIXME|placeholder|stub|not yet|deferred" "$P/src" | grep -v /build/
+# stub feature writes (no-op returns on a feature path):
+grep -rnE "return emptyList\(\)" "$P/src/main"
+# icon must not be a copy of the reference plugin:
+md5sum "$P/src/main/assets/icon_day.png" random-xkcd/src/main/assets/icon_day.png
+# metadata at a glance (expect org.appdevforall.<plugin>):
+grep -nE "namespace|applicationId|pluginName" "$P/build.gradle.kts"
+grep -A1 "plugin.(id|name|author|min_ide_version|main_class|permissions)" "$P/src/main/AndroidManifest.xml" | grep -E "value|name"
+# registered to actually deploy?:
+grep -q "\"$P\"" .github/workflows/update-libs.yml && echo "in update-libs MAP" || echo "MISSING from update-libs MAP"
+```
+
+Read every line of output, plus the `app_name` / `plugin.name` / label / tab strings by eye. Clean
+output is a precondition for "done," not proof of it — finish the checklist above.

--- a/architecture.md
+++ b/architecture.md
@@ -1,0 +1,195 @@
+# Architecture & Layering (plugin-examples)
+
+This is this repo's guide to how we structure code: how a module's code is split into layers,
+which way dependencies are allowed to point, and a practical checklist for keeping each class
+focused. `REVIEW.md`'s structure/SRP gate points here, so this is the single source of truth —
+read it when designing or reviewing code.
+
+These are **conventions upheld by review, not rules enforced by tooling.** There is no linter
+or CI check that fails a build for breaking them. Apply them when you design code and check
+them again when you review it. A passing build tells you the code compiles — not that it is
+structured well.
+
+## What "layering" means
+
+Layering is the practice of splitting code into groups (layers) by *what kind of work each
+group does*, and then restricting which layers are allowed to call which. The goal is to keep
+**pure logic** — code that just computes results from inputs — separate from **Android/UI
+code** — code that draws screens, handles taps, and talks to the operating system.
+
+Why bother? Pure logic separated from Android is **unit-testable on a normal JVM**: you can run
+it in a fast test without an Android device or emulator. (For context, Android UI classes
+normally need either a device or a tool like *Robolectric*, which simulates Android in a test —
+both are slower and more fragile than a plain JVM test.) Separation also limits how far a bug or
+a change can spread, which the rest of this doc returns to repeatedly.
+
+Layering applies at two scales: **within a single module**, and **across modules**.
+
+## Layering within a module: `data/ · domain/ · ui/ · di/`
+
+Inside a module, code is split into four packages. The diagram shows what each holds and which
+packages may depend on which (an arrow means "may use / call into"):
+
+```mermaid
+flowchart TD
+    ui["ui/ — Activities, Fragments, ViewModels, adapters, custom views"]
+    di["di/ — wires the other layers together (the only layer that knows them all)"]
+    domain["domain/ — pure business logic + value/domain types. NO Android imports."]
+    data["data/ — repositories, file I/O, parsing, persistence, network"]
+
+    ui --> domain
+    ui --> di
+    data --> domain
+    di --> domain
+    di --> data
+    di --> ui
+```
+
+- **`domain/`** is the foundation. It is pure Kotlin — no `android.*` or `androidx.*` imports,
+  no `Context` (the Android object that gives access to system services and resources). It holds
+  *value types* and *domain models* (plain data classes describing the concepts the app works
+  with) and the business logic that operates on them. Because it touches no Android, it is the
+  most easily unit-tested layer.
+- **`data/`** does input/output: *repositories* (classes that fetch and store data behind a
+  clean interface), file access, parsing, saving/loading, and network calls. It depends *down*
+  on `domain/` (it produces and consumes domain types) and never *up* on `ui/`.
+- **`ui/`** is everything the user sees and touches: Activities and Fragments (Android's screen
+  and screen-section classes), *ViewModels* (classes that hold screen state and survive rotation),
+  list adapters, and custom views. It depends down on `domain/`, and through `di/` on `data/`.
+  Nothing depends on `ui/`.
+- **`di/`** is the *dependency-injection* / wiring layer — the code that constructs objects and
+  hands each one the collaborators it needs (whether via a framework like Hilt or done by hand).
+  It is allowed to know all three other layers because composing them is its entire job.
+
+## Layering across modules: the api/impl split
+
+At the larger scale, a *module* is a separately-built unit of code with its own dependencies.
+A feature is often split into two modules:
+
+- An **api module** — the stable *contract*: the interfaces and value types that describe what
+  the feature offers, with no implementation detail. Example: `editor-api`.
+- An **impl module** — the actual implementation behind that contract. Example: `editor`.
+
+Other code depends on the **api** module only; just the single top-level assembly point (the
+"composition root" — the place where the whole app is wired together) depends on the **impl**.
+This means a change inside `editor` can't ripple out to everything that uses the editor, because
+those callers only ever saw `editor-api`.
+
+### `compileOnly` and the plugin contract
+
+Plugins push this idea further. A plugin depends on the host's `plugin-api` module as a
+**`compileOnly`** dependency. `compileOnly` is a Gradle dependency scope meaning "I need this to
+*compile* against, but do **not** bundle it into my output — the runtime environment already
+provides it." So a plugin compiles against the host's API but ships without a copy of it; the
+host supplies the real classes at load time, and the host owns and versions that API.
+
+### Plugins are single-module — skip the api/impl split
+
+A single-module plugin has nowhere to put a separate api module, so the api/impl split does not
+apply to plugins. For a plugin, only the in-module `data/domain/ui` layering applies. Don't
+create extra modules just to imitate the split.
+
+## The dependency-direction rule
+
+> **Dependencies flow *down* toward `domain/`. `domain/` depends on nothing above it. No layer
+> ever depends "up" into `ui/`.**
+
+"Dependency direction" just means which way the `import`/call arrows point. "Down" means toward
+`domain/`; "up" means toward `ui/`. Concretely:
+
+- **Domain/value types live in `domain/`, not in a `ui/` package.** Don't define a data type in,
+  say, a `wizard/` UI package just because the wizard is the first thing that happens to use it.
+- **Pure logic lives in `domain/`** so it can be unit-tested on a JVM without an Android `Context`.
+- **No dependency cycles between packages or modules.** A cycle (A depends on B, and B depends
+  back on A) almost always means a shared type is sitting in the wrong layer. Pull it down into
+  `domain/`, and both sides can depend on it instead of on each other.
+
+## Keep the blast radius small
+
+"Blast radius" is how much of the system a single change or bug can affect. The guiding
+principle: **keep it small.** A change should touch as few things as possible, and a bug in one
+place should not be able to break unrelated code.
+
+Layering is the *mechanism* for a small blast radius. Pure logic isolated in `domain/` can't
+break the UI; swapping a repository in `data/` can't ripple into business rules; a `compileOnly`
+plugin contract stops a plugin from reaching into the host's internals. When you make a
+structural decision, ask: "if this turns out to be wrong, what's the blast radius?" — and prefer
+the shape that contains it.
+
+## Don't over-apply layering to a small plugin
+
+"Clean Architecture" is the broader school of thought these layers come from; its full form
+involves many packages and interfaces. Don't impose all of that on a small plugin.
+
+The `data/domain/ui` split earns its keep once a plugin has real logic worth isolating — a
+parser, a state machine, a code generator. A tiny plugin with one Fragment and no business logic
+does **not** need three packages and a wiring layer. Apply layering in proportion to the logic
+that actually exists. Reference plugins especially should stay minimal and clear, since other
+authors learn from them.
+
+## SRP — keeping each class focused
+
+The **Single Responsibility Principle (SRP)** says a class should have one job — one reason to
+change. "One job" is fuzzy, so instead of debating it abstractly, judge it with four concrete
+checks:
+
+1. **UI vs. logic separation.** A Fragment or Activity should *only* handle Android lifecycle,
+   wiring up views, and routing user input. The moment it **formats data, makes a business
+   decision, or directly does file I/O or network calls**, it has taken on logic that belongs in
+   a **ViewModel** or a **domain class / use-case**. (This is also why I/O doesn't belong in a
+   Fragment in the first place — it should run off the main thread, in a lower layer.)
+2. **The "and" test.** If you can't describe the class without saying **"and"** — "it picks a
+   bounding box *and* formats the coordinates *and* saves them" — it is holding too many jobs.
+3. **Dependency bloat.** If a class or ViewModel needs **more than ~4–5 injected repositories or
+   services**, it is orchestrating too much. Split it into focused use-cases.
+4. **Line count (soft signal).** Not a hard limit, but a file past **~300–400 lines** is a strong
+   hint that responsibilities are piling up. Go look.
+
+When a check fires, here's how to decide whether to actually split:
+
+- **Split when** the parts **change for different reasons** *and* **at least one part is
+  independently testable** (pure logic, no `Context`).
+- **Naming test:** if you can't name the piece you'd extract without using "and," or the best
+  name you can think of is a vague `Manager` / `Helper` / `Util`, the seam isn't real yet — leave
+  it.
+- **Don't split a cohesive class just because it's long.** A self-contained algorithm, or a custom
+  `View`'s drawing code, is *one* responsibility even past 500 lines.
+
+### Wizards and other multi-step flows
+
+For a multi-step flow (a setup wizard, a checkout sequence), prefer **one small Fragment or view
+per step, all coordinated by a single shared ViewModel or state machine** that owns the overall
+state and transitions. Avoid one big host Fragment that holds every step's state and all the
+transition logic — that's an SRP violation by construction.
+
+## The coupling & cohesion / layering audit
+
+Run these five questions at **design time** (does the plan put each piece in the right layer?)
+and again at **review time** (did the implementation drift from the plan?):
+
+1. **Is the same behavior/logic duplicated across more than one module?** Copy-pasted helpers, a
+   shared mutable contract, the same rule implemented twice — give it one home.
+2. **Are there dependency cycles, or low-level code depending "up" into UI?**
+3. **Is any module or Fragment a "god object"** doing I/O *and* orchestration *and* UI in one
+   class?
+4. **Are domain/value types living in UI packages** instead of in `domain/`?
+5. **Is pure logic separated from Android/UI** so it can be unit-tested on a JVM without a
+   `Context`?
+
+## Code-documentation conventions
+
+A **strong de-facto convention upheld by review, not a hard gate** — CI won't fail a build for a
+missing doc comment, but reviewers expect these:
+
+- **KDoc on classes and non-trivial functions.** KDoc is Kotlin's documentation-comment format
+  (`/** … */`, the Kotlin equivalent of Javadoc). Lead with a one-sentence summary, then add
+  `@param`/`@return` lines only where they aren't obvious. Skip doc comments on trivial
+  pass-throughs and self-explanatory one-liners. Document the *why* and the non-obvious, not the
+  restating of an obvious signature.
+- **Formatting:** use `ktfmt` (Google style) for Kotlin and `google-java-format` (Google style)
+  for Java, both with **2-space indentation**. These are auto-formatters; run them rather than
+  hand-formatting.
+- **No GPL `@author` header in plugin files.** CoGo (the host IDE) descends from the AndroidIDE
+  project and inherits its GPL license header, including an `@author` tag, on many files. Plugins
+  are **not** GPL-licensed and must **not** carry that header. Don't copy it into a plugin file
+  just because a CoGo file you borrowed from has it.


### PR DESCRIPTION
Prototype Claude agent setup in this repo for the ADFA team — it brings in shared skills from the `common-agent-setup` repo and sets up a few key items:

- **`.claude/settings.json`** — registers the `common-agent-setup` marketplace and enables the `adfa-agent` plugin, so an agent session here automatically gets the shared workflow skills: `plan-for-done`, `check-done`, `prepare-pr`, `android-qa`, `ux-review`, `retro`.
- **`REVIEW.md`** — this repo's complete definition of done: core gates (builds, tests/coverage, no main-thread I/O, structure/SRP, code review, on-device QA + UX review, docs) plus plugin-specific gates (naming coherence, no placeholder assets, feature-completeness, manifest/permissions, host-integration correctness, the submission gauntlet) and a paste-ready sweep. `plan-for-done` / `check-done` read this file.
- **`architecture.md`** — layering / dependency-direction / SRP conventions referenced by REVIEW.md.
- **`.claude/skills/android-qa-plugins/`** — CoGo-plugin-specific on-device QA notes (install flow, IDE navigation, plugin-load failure modes, emulator bootstrap) that supplement the plugin's generic `android-qa` skill.
- **`CLAUDE.md`** — points agents at the plugin's skills and at this repo's REVIEW.md.

Docs/config only — no plugin source or build changes.

## Notes
- First-time install requires GitHub access to the `appdevforall/common-agent-setup` marketplace repo (where the `adfa-agent` plugin lives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)