### PR TITLE
Fix: AI Literacy Course PDFs won't open (render via bundled PDF.js)

### DIFF
--- a/ai-literacy-course/.gitignore
+++ b/ai-literacy-course/.gitignore
@@ -30,3 +30,6 @@ test-results/
 
 # Course bundle is fetched at build time by the downloadAssets task — never commit it.
 src/main/assets/ai-literacy-course.zip
+
+# PDF.js viewer is fetched at build time by the downloadAssets task — never commit it.
+src/main/assets/pdfjs.zip

--- a/ai-literacy-course/build.gradle.kts
+++ b/ai-literacy-course/build.gradle.kts
@@ -3,6 +3,9 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.net.URL
 import java.net.HttpURLConnection
 import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
 
 plugins {
     id("com.android.application")
@@ -82,10 +85,10 @@ tasks.matching {
     enabled = false
 }
 
-// --- Build-time course download (mirrors ndk-installer-plugin) ---------------
+// --- Build-time asset downloads (mirrors ndk-installer-plugin) ---------------
 //
-// The 110 MB course ZIP is NOT committed to git. This task pulls it from LAIA's
-// Google Drive and verifies a self-computed MD5 we pin below. scripts/update-libs.sh
+// Neither the 110 MB course ZIP nor the PDF.js viewer is committed to git. This
+// task pulls each from its source and verifies a pinned MD5. scripts/update-libs.sh
 // runs `downloadAssets` automatically before assemblePlugin for any plugin that
 // declares it.
 
@@ -130,6 +133,27 @@ fun httpDownloadToFile(url: String, target: File): Long {
     return receivedLength
 }
 
+/**
+ * Copy [src] zip to [dest], dropping `*.map` source-map entries. The official
+ * PDF.js dist ships ~9 MB of source maps that point at TypeScript we don't bundle
+ * — dead weight inside the .cgp and on-device. Everything else is passed through
+ * verbatim, so [dest] keeps the dist's `build/` + `web/` root layout that
+ * CourseInstaller extracts.
+ */
+fun repackWithoutMaps(src: File, dest: File) {
+    ZipInputStream(src.inputStream().buffered()).use { zin ->
+        ZipOutputStream(dest.outputStream().buffered()).use { zout ->
+            while (true) {
+                val entry = zin.nextEntry ?: break
+                if (entry.isDirectory || entry.name.endsWith(".map")) continue
+                zout.putNextEntry(ZipEntry(entry.name))
+                zin.copyTo(zout)
+                zout.closeEntry()
+            }
+        }
+    }
+}
+
 fun md5Of(file: File): String {
     val md = MessageDigest.getInstance("MD5")
     file.inputStream().use { input ->
@@ -143,58 +167,90 @@ fun md5Of(file: File): String {
     return md.digest().joinToString("") { "%02x".format(it) }
 }
 
-val downloadAssets by tasks.registering {
-    val assetsDir = project.file("src/main/assets")
-    val archiveFile = assetsDir.resolve("ai-literacy-course.zip")
+/**
+ * Download [url] to [target], retrying with backoff, and fail the build unless
+ * the bytes hash to [expectedMd5]. The MD5 gate is the real integrity check:
+ * it also catches a host serving an HTML interstitial/quota page instead of the
+ * file (Google Drive does this), since that won't match the pinned hash.
+ */
+fun org.gradle.api.Task.downloadVerified(
+    url: String,
+    target: File,
+    expectedMd5: String,
+    label: String,
+    maxAttempts: Int = 3,
+) {
+    var lastError: String? = null
+    for (attempt in 1..maxAttempts) {
+        logger.lifecycle("Downloading $label (attempt $attempt/$maxAttempts)...")
+        try {
+            val bytes = httpDownloadToFile(url, target)
+            val actualMd5 = md5Of(target).lowercase()
+            logger.info("Downloaded $bytes bytes; expected MD5=$expectedMd5 actual=$actualMd5")
+            if (expectedMd5 == actualMd5) return
+            lastError = "MD5 mismatch (expected=$expectedMd5, actual=$actualMd5)."
+        } catch (e: Exception) {
+            lastError = e.message ?: e.javaClass.simpleName
+        }
+        logger.warn("Attempt $attempt failed: $lastError")
+        target.delete()
+        if (attempt < maxAttempts) {
+            val backoffMs = 2_000L * attempt
+            logger.lifecycle("Retrying in ${backoffMs}ms...")
+            Thread.sleep(backoffMs)
+        }
+    }
+    throw GradleException("Failed to download $label after $maxAttempts attempts: $lastError")
+}
 
-    outputs.files(archiveFile)
+val downloadCourse by tasks.registering {
+    val courseArchive = project.file("src/main/assets/ai-literacy-course.zip")
+    outputs.files(courseArchive)
 
     doLast {
-        assetsDir.mkdirs()
-
-        // Google Drive large-file (>100 MB) endpoint. A plain share/uc URL would
-        // return an HTML "can't scan for viruses" interstitial instead of bytes;
-        // this endpoint + confirm=t serves the file directly.
+        courseArchive.parentFile.mkdirs()
+        // Google Drive large-file (>100 MB) endpoint. A plain share/uc URL returns
+        // an HTML "can't scan for viruses" interstitial instead of bytes; this
+        // endpoint + confirm=t serves the file directly. MD5 from the LAIA-provided
+        // zip (110 MB -> 119 MB extracted).
         val fileId = "1zRTVzgzZwVCtij55JnFTLtPFwsSlZo-t"
-        val archiveUrl =
-            "https://drive.usercontent.google.com/download?id=$fileId&export=download&confirm=t"
-
-        // MD5 computed from the LAIA-provided zip (110 MB -> 119 MB extracted).
-        // A mismatch (including Drive returning an HTML/quota page) fails the build.
-        val expectedMd5 = "c2785f29c12056bd54b8cc885355ecc9"
-        val maxAttempts = 3
-
-        var lastError: String? = null
-        for (attempt in 1..maxAttempts) {
-            logger.lifecycle("Downloading AI Literacy course bundle (attempt $attempt/$maxAttempts)...")
-            try {
-                val bytes = httpDownloadToFile(archiveUrl, archiveFile)
-                val actualMd5 = md5Of(archiveFile).lowercase()
-
-                logger.info("Downloaded $bytes bytes")
-                logger.info("Expected MD5: $expectedMd5")
-                logger.info("Actual MD5:   $actualMd5")
-
-                if (expectedMd5 == actualMd5) {
-                    return@doLast
-                }
-                lastError = "MD5 mismatch (expected=$expectedMd5, actual=$actualMd5). " +
-                    "Drive may have served an HTML interstitial/quota page, or the bundle changed."
-            } catch (e: Exception) {
-                lastError = e.message ?: e.javaClass.simpleName
-            }
-
-            logger.warn("Attempt $attempt failed: $lastError")
-            archiveFile.delete()
-            if (attempt < maxAttempts) {
-                val backoffMs = 2_000L * attempt
-                logger.lifecycle("Retrying in ${backoffMs}ms...")
-                Thread.sleep(backoffMs)
-            }
-        }
-
-        throw GradleException(
-            "Failed to download ai-literacy-course.zip after $maxAttempts attempts: $lastError"
+        val url = "https://drive.usercontent.google.com/download?id=$fileId&export=download&confirm=t"
+        downloadVerified(
+            url, courseArchive,
+            expectedMd5 = "c2785f29c12056bd54b8cc885355ecc9",
+            label = "AI Literacy course bundle",
         )
     }
+}
+
+val downloadPdfjs by tasks.registering {
+    val pdfjsArchive = project.file("src/main/assets/pdfjs.zip")
+    outputs.files(pdfjsArchive)
+
+    doLast {
+        pdfjsArchive.parentFile.mkdirs()
+        // A bare WebView can't render application/pdf, so the course shell links
+        // each PDF through this bundled viewer. Pin the modern (.mjs) dist, verify
+        // its MD5, then strip ~9 MB of source maps into pdfjs.zip. The dist's
+        // build/ + web/ root layout is what CourseInstaller extracts.
+        val version = "4.8.69"
+        val url =
+            "https://github.com/mozilla/pdf.js/releases/download/v$version/pdfjs-$version-dist.zip"
+        val download = File.createTempFile("pdfjs-dist", ".zip")
+        try {
+            downloadVerified(
+                url, download,
+                expectedMd5 = "772b68fe1f36e3df7c0827bb4f3e1cec",
+                label = "PDF.js $version dist",
+            )
+            repackWithoutMaps(download, pdfjsArchive)
+        } finally {
+            download.delete()
+        }
+    }
+}
+
+// Aggregator: scripts/update-libs.sh runs `downloadAssets` before assemblePlugin.
+val downloadAssets by tasks.registering {
+    dependsOn(downloadCourse, downloadPdfjs)
 }

--- a/ai-literacy-course/src/main/kotlin/org/appdevforall/ailiteracycourse/CourseInstaller.kt
+++ b/ai-literacy-course/src/main/kotlin/org/appdevforall/ailiteracycourse/CourseInstaller.kt
@@ -23,7 +23,14 @@ import java.io.File
 object CourseInstaller {
 
     private const val BUNDLE_ASSET = "ai-literacy-course.zip"
-    private const val INSTALL_VERSION = 1
+
+    // Mozilla PDF.js (Apache-2.0), bundled so PDF resources render offline. A
+    // bare WebView can't display application/pdf, so the shell links each PDF
+    // through this viewer (served same-origin from <root>/pdfjs/web/viewer.html).
+    private const val PDFJS_ASSET = "pdfjs.zip"
+
+    // Bumped to 2 to force existing installs to re-extract with the PDF viewer.
+    private const val INSTALL_VERSION = 2
     private const val MARKER = ".installed-v$INSTALL_VERSION"
 
     private val installLock = Any()
@@ -66,12 +73,32 @@ object CourseInstaller {
             onStatus("Unpacking activities…")
             extractNestedZips(archive, root)
 
+            onStatus("Preparing PDF viewer…")
+            installPdfViewer(context, archive, root)
+
             onStatus("Building course…")
             CourseShell.generate(root)
 
             marker.writeText("ok")
             root
         }
+
+    /**
+     * Unpack the bundled PDF.js viewer into `<root>/pdfjs/` so it is served from
+     * the same virtual https origin as the course PDFs. Same-origin is required:
+     * PDF.js's viewer rejects a `?file=` URL from a different origin, and the
+     * worker/asset fetches must resolve under the same host.
+     */
+    private fun installPdfViewer(context: PluginContext, archive: IdeArchiveService, root: File) {
+        val dest = File(root, "pdfjs")
+        dest.mkdirs()
+        val source = context.resources.openPluginAsset(PDFJS_ASSET)
+            ?: error("Bundled asset not found: $PDFJS_ASSET")
+        val result = source.use {
+            archive.extract(it, ArchiveFormat.ZIP, dest, null)
+        }
+        if (result is ExtractResult.Failure) throw result.error
+    }
 
     /**
      * The bundle wraps everything in a single top folder; descend into it so

--- a/ai-literacy-course/src/main/kotlin/org/appdevforall/ailiteracycourse/CourseShell.kt
+++ b/ai-literacy-course/src/main/kotlin/org/appdevforall/ailiteracycourse/CourseShell.kt
@@ -8,7 +8,8 @@ import java.io.File
  * The bundle ships no web shell of its own — just numbered folders of `.mp4`
  * videos, `.pdf` resources, and HTML activities. This walks that regular
  * structure and emits a single video-forward page: lessons in playback order,
- * each video inline, activities and PDFs as links the WebView opens in place.
+ * each video inline, activities as links the WebView opens in place, and PDFs
+ * opened through the bundled PDF.js viewer (a bare WebView can't render PDFs).
  *
  * All links are relative to the page (served at `…/course/index.html`), so they
  * resolve under the same virtual https origin.
@@ -75,8 +76,19 @@ object CourseShell {
         """.trimIndent() + "\n"
 
         Kind.ACTIVITY -> link(item, "Activity")
-        Kind.PDF -> link(item, "PDF")
+        Kind.PDF -> link(item.copy(href = pdfViewerHref(item.href)), "PDF")
     }
+
+    /**
+     * Wrap a PDF's page-relative URL in the bundled PDF.js viewer. The viewer
+     * lives at `pdfjs/web/viewer.html`, two levels below the page root, so the
+     * PDF is reached back up via `../../`. Resolved against the viewer's URL,
+     * this stays on the same origin — which PDF.js requires for `?file=`.
+     * Course resource names are URL-safe kebab-case, so [rel] needs no further
+     * encoding as a query value.
+     */
+    private fun pdfViewerHref(rel: String): String =
+        "pdfjs/web/viewer.html?file=../../$rel"
 
     private fun link(item: Item, badge: String): String = """
         <a class="item link" href="${attr(item.href)}">

--- a/ai-literacy-course/src/main/kotlin/org/appdevforall/ailiteracycourse/fragments/CourseFragment.kt
+++ b/ai-literacy-course/src/main/kotlin/org/appdevforall/ailiteracycourse/fragments/CourseFragment.kt
@@ -288,6 +288,7 @@ class CourseFragment : Fragment() {
             "woff2" -> "font/woff2"
             "ttf" -> "font/ttf"
             "txt", "md" -> "text/plain"
+            "ftl" -> "text/plain"          // PDF.js viewer locale (Fluent) files
             else -> "application/octet-stream"
         }
     }


### PR DESCRIPTION
## Problem
Users report they **cannot open any of the PDF files** in the AI Literacy Course (teacher guide, intro slides, worksheets).

**Root cause:** the course shell links each PDF as a bare `<a href="…pdf">`. Clicking navigates the WebView to a URL served as `application/pdf` — but Android's WebView has **no built-in PDF renderer**, so it shows a blank page. The plugin is deliberately fully offline (no `network.access`, no download listener, no external-viewer fallback), so every normal fallback is closed and *all* PDFs fail identically.

## Fix
Bundle Mozilla **PDF.js** (modern `.mjs` dist, v4.8.69) and serve it from the **same virtual https origin** as the course content, so PDF links open in-place through the viewer.

- **`build.gradle.kts`** — PDF.js is fetched at **build time** (MD5-verified) and source-maps stripped into `pdfjs.zip`; **not committed to git** (mirrors the existing course-bundle download). `downloadAssets` split into independent `downloadCourse` / `downloadPdfjs` tasks behind an aggregator so rebuilds don't re-pull the 115 MB course.
- **`CourseInstaller.kt`** — extracts the viewer to `<root>/pdfjs/`; `INSTALL_VERSION` bumped so existing installs re-extract.
- **`CourseShell.kt`** — PDFs now link through `pdfjs/web/viewer.html?file=../../<pdf>` (same-origin, which PDF.js's `validateFileURL` requires).
- **`CourseFragment.kt`** — serves `.ftl` viewer locale files as `text/plain`.

No new permissions; stays fully offline.

## Verification
- ✅ `downloadPdfjs` downloads + MD5-verifies + repacks (`pdfjs.zip`, **0 `.map` files**).
- ✅ `assemblePlugin` builds; `.cgp` contains `assets/pdfjs.zip` with no source-maps.
- ✅ **On-device** (Android WebView engine), the viewer renders the real course PDFs through the exact plugin URL flow — including the **15 MB / 228-page slide deck**.
- ⚠️ Not done: full end-to-end install via CoGo's Plugin Manager + opening a PDF from the sidebar (manual step). The rendering pipeline that was broken is verified on-device.

## Notes for reviewers
- Pinned PDF.js **v4.8.69** (Nov 2024). Same major line as the v4 build Code on the Go ships in `documentation.db`; happy to match the exact host version if preferred.