### PR TITLE
Fix AI Literacy Course lesson-item ordering

### DIFF
--- a/ai-literacy-course/src/main/kotlin/org/appdevforall/ailiteracycourse/CourseInstaller.kt
+++ b/ai-literacy-course/src/main/kotlin/org/appdevforall/ailiteracycourse/CourseInstaller.kt
@@ -29,8 +29,9 @@ object CourseInstaller {
     // through this viewer (served same-origin from <root>/pdfjs/web/viewer.html).
     private const val PDFJS_ASSET = "pdfjs.zip"
 
-    // Bumped to 2 to force existing installs to re-extract with the PDF viewer.
-    private const val INSTALL_VERSION = 2
+    // Bumped to 3 to force existing installs to re-extract and regenerate the
+    // navigation shell with the corrected lesson-item ordering.
+    private const val INSTALL_VERSION = 3
     private const val MARKER = ".installed-v$INSTALL_VERSION"
 
     private val installLock = Any()

--- a/ai-literacy-course/src/main/kotlin/org/appdevforall/ailiteracycourse/CourseShell.kt
+++ b/ai-literacy-course/src/main/kotlin/org/appdevforall/ailiteracycourse/CourseShell.kt
@@ -36,25 +36,25 @@ object CourseShell {
 
     private enum class Kind { VIDEO, ACTIVITY, PDF }
 
-    private data class Item(val title: String, val href: String, val kind: Kind)
+    private data class Item(val order: Int, val title: String, val href: String, val kind: Kind)
 
     private fun itemsOf(root: File, section: File): List<Item> {
         val entries = section.listFiles() ?: return emptyList()
         return entries.mapNotNull { entry ->
             when {
                 entry.isFile && entry.extension.equals("mp4", true) ->
-                    Item(itemTitle(entry.nameWithoutExtension), rel(root, entry), Kind.VIDEO)
+                    Item(leadingNumber(entry.nameWithoutExtension), itemTitle(entry.nameWithoutExtension), rel(root, entry), Kind.VIDEO)
 
                 entry.isFile && entry.extension.equals("pdf", true) ->
-                    Item(itemTitle(entry.nameWithoutExtension), rel(root, entry), Kind.PDF)
+                    Item(leadingNumber(entry.nameWithoutExtension), itemTitle(entry.nameWithoutExtension), rel(root, entry), Kind.PDF)
 
                 entry.isDirectory -> findIndexHtml(entry)?.let { index ->
-                    Item(itemTitle(entry.name), rel(root, index), Kind.ACTIVITY)
+                    Item(leadingNumber(entry.name), itemTitle(entry.name), rel(root, index), Kind.ACTIVITY)
                 }
 
                 else -> null
             }
-        }.sortedWith(compareBy({ leadingNumber(it.title) }, { it.title }))
+        }.sortedWith(compareBy({ it.order }, { it.title }))
     }
 
     /** Shallowest index.html under [dir] (activities nest theirs differently). */
@@ -124,8 +124,14 @@ object CourseShell {
     private fun itemTitle(raw: String): String =
         titleCase(raw.replace(Regex("^\\d+-"), ""))
 
-    private fun leadingNumber(title: String): Int =
-        Regex("(\\d+)").find(title)?.groupValues?.get(1)?.toIntOrNull() ?: Int.MAX_VALUE
+    /**
+     * The leading "12-" ordering prefix of a raw file/dir name, as an int.
+     * Anchored to the start so a number later in the name (e.g. the "1" in
+     * "5-lesson-1-recap-quiz") can't be mistaken for the ordering key.
+     * Unnumbered entries sort last.
+     */
+    private fun leadingNumber(rawName: String): Int =
+        Regex("^(\\d+)").find(rawName)?.groupValues?.get(1)?.toIntOrNull() ?: Int.MAX_VALUE
 
     private fun titleCase(raw: String): String =
         raw.split('-', ' ', '_').filter { it.isNotBlank() }.joinToString(" ") { w ->


### PR DESCRIPTION
## Problem

The AI Literacy Course presented lesson items in the wrong order — it did not match the numbered sequence in the course bundle (`1-objectives.mp4`, `2-what-is-ai.mp4`, … `7-lesson-1-worksheet.zip`).

## Root cause

`CourseShell.itemsOf()` sorted with `compareBy({ leadingNumber(it.title) }, { it.title })`, but `Item.title` had already had its `N-` ordering prefix stripped by `itemTitle()`. The old `leadingNumber` regex `(\d+)` then matched the *first digit anywhere* in the stripped title. Two failures compounded:

- Genuinely-first items like `1-objectives` → `"Objectives"` had no digit left → `Int.MAX_VALUE` → sorted **last**.
- Items whose text contains a number, e.g. `5-lesson-1-recap-quiz` → `"Lesson 1 Recap Quiz"`, picked up the embedded `1` → sorted **first**.

Result for Lesson 1 (buggy): Project Time → Recap Quiz → Worksheet → AI Or Not Quiz → How AI Can Help Us → Objectives → What Is AI.

Section-level ordering was already correct (`sectionOrder()` keys off the raw folder name); only intra-section item order was broken.

## Fix

- Add `order: Int` to `Item`, computed via `leadingNumber(...)` from the **original file/dir name** (before `itemTitle()` strips the prefix), and sort by `it.order` then title.
- Anchor `leadingNumber` to `^(\d+)` so it can only read the leading ordering prefix, never a digit embedded later in the name.

After the fix, Lesson 1 renders: Objectives → What Is AI → AI Or Not Quiz → How AI Can Help Us → Lesson 1 Recap Quiz → Lesson 1 Project Time → Lesson 1 Worksheet.

`CourseShell.generate()` only runs during `CourseInstaller.ensureInstalled()`, which is gated by an install-version marker, so `INSTALL_VERSION` is bumped 2 → 3 to force existing installs to re-extract and regenerate `index.html` with the corrected order.

## Verification

- Ported the exact old vs. new sort to a mock lesson tree: BEFORE reproduced the scramble, AFTER matched the numeric-prefix order exactly.
- Built the `.cgp` and installed on device (Samsung S22). Confirmed lessons now list items in numbered order. (Surfaced and fixed a separate pre-existing issue in the process: `pdfjs.zip` is a build-time downloaded asset, and a bare `assemblePlugin` without a prior `downloadAssets` ships a viewer-less `.cgp`; re-fetched before the device test — see note below.)

## Note / possible follow-up

`./gradlew assemblePlugin` silently produces a broken plugin if the downloaded assets (`pdfjs.zip`, `ai-literacy-course.zip`) aren't present, with no build-time warning — only `scripts/update-libs.sh` runs `downloadAssets` first. A follow-up could make `assemblePlugin` fail fast (or depend on `downloadAssets`) when those assets are missing. Not included here to keep this PR scoped to the ordering fix.