### PR TITLE
ci: allow building a single plugin via workflow input

### DIFF
--- a/.github/workflows/build-plugins.yml
+++ b/.github/workflows/build-plugins.yml
@@ -13,6 +13,10 @@ on:
         description: CodeOnTheGo branch or tag to build the libs against
         required: false
         default: stage
+      plugin:
+        description: Build only this plugin (folder name, e.g. random-xkcd). Leave empty to build all.
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -42,10 +46,18 @@ jobs:
       - name: Build libs and plugins
         env:
           CODEONTHEGO_REF: ${{ github.event.inputs.codeonthego_ref }}
-        run: ./scripts/update-libs.sh --ref "$CODEONTHEGO_REF"
+          ONLY_PLUGIN: ${{ github.event.inputs.plugin }}
+        run: |
+          if [ -n "$ONLY_PLUGIN" ]; then
+            ./scripts/update-libs.sh --ref "$CODEONTHEGO_REF" --plugin "$ONLY_PLUGIN"
+          else
+            ./scripts/update-libs.sh --ref "$CODEONTHEGO_REF"
+          fi
 
       - name: Stage built .cgp artifacts
         id: stage
+        env:
+          ONLY_PLUGIN: ${{ github.event.inputs.plugin }}
         run: |
           mkdir -p deploy-staging
 
@@ -63,6 +75,11 @@ jobs:
             [ -f "$build_file" ] || continue
             grep -qF "com.itsaky.androidide.plugins.build" "$build_file" || continue
             module="$(dirname "$build_file")"
+            # When a single plugin was requested, only that module was built —
+            # skip every other module so its absent .cgp is not treated as an error.
+            if [ -n "$ONLY_PLUGIN" ] && [ "$module" != "$ONLY_PLUGIN" ]; then
+              continue
+            fi
             skip=0
             for s in "${SKIP_PLUGINS[@]}"; do
               [ "$s" = "$module" ] && skip=1 && break

--- a/scripts/update-libs.sh
+++ b/scripts/update-libs.sh
@@ -7,6 +7,7 @@
 #   ./scripts/update-libs.sh                      # clone/pull github.com/appdevforall/CodeOnTheGo into .cache/, build from stage
 #   ./scripts/update-libs.sh --ref main           # build from a different branch or tag
 #   ./scripts/update-libs.sh --local ../CodeOnTheGo  # use an existing local checkout instead of cloning
+#   ./scripts/update-libs.sh --plugin random-xkcd # refresh libs, then build only this one plugin
 #
 set -euo pipefail
 
@@ -20,6 +21,7 @@ CACHE_DIR="$REPO_ROOT/.cache/CodeOnTheGo"
 
 LOCAL_PATH=""
 REF="$DEFAULT_REF"
+ONLY_PLUGIN=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -35,6 +37,14 @@ while [ $# -gt 0 ]; do
             REF="${2:-}"
             if [ -z "$REF" ]; then
                 echo "Error: --ref requires a branch or tag argument." >&2
+                exit 1
+            fi
+            shift 2
+            ;;
+        --plugin)
+            ONLY_PLUGIN="${2:-}"
+            if [ -z "$ONLY_PLUGIN" ]; then
+                echo "Error: --plugin requires a plugin name argument." >&2
                 exit 1
             fi
             shift 2
@@ -136,6 +146,22 @@ done
 if [ "${#PLUGINS[@]}" -eq 0 ]; then
     echo "Error: no example plugins discovered (looked for sibling dirs whose build.gradle.kts applies $PLUGIN_BUILDER_ID)." >&2
     exit 1
+fi
+
+if [ -n "$ONLY_PLUGIN" ]; then
+    found=0
+    for p in "${PLUGINS[@]}"; do
+        if [ "$p" = "$ONLY_PLUGIN" ]; then
+            found=1
+            break
+        fi
+    done
+    if [ "$found" -eq 0 ]; then
+        echo "Error: requested plugin '$ONLY_PLUGIN' is not a buildable example plugin." >&2
+        echo "Available plugins: ${PLUGINS[*]}" >&2
+        exit 1
+    fi
+    PLUGINS=("$ONLY_PLUGIN")
 fi
 
 echo ""


### PR DESCRIPTION
Add an optional 'plugin' workflow_dispatch input to the Build plugin artifacts workflow. When set to a plugin folder name, only that plugin is built and published; when empty, all plugins build as before.

Backs it with a new --plugin <name> option in scripts/update-libs.sh that validates the name against the discovered plugin list (fail-fast if unknown or skipped) and restricts the build loop to that plugin. The workflow staging step skips other modules so their absent .cgp is not treated as an error, and the publish matrix fans out just the one.