### PR TITLE
ADFA-3857: fix update-libs.sh gradlew fallback for wrapper-less plugins

### DIFF
--- a/scripts/update-libs.sh
+++ b/scripts/update-libs.sh
@@ -172,10 +172,14 @@ for plugin in "${PLUGINS[@]}"; do
     echo "→ $plugin"
     (
         cd "$REPO_ROOT/$plugin"
+        # Newer plugins (e.g. flutter-template) drop their per-plugin wrapper and
+        # use the repo-root gradlew; fall back to it when no local gradlew exists.
+        gradlew="./gradlew"
+        [ -x "$gradlew" ] || gradlew="$REPO_ROOT/gradlew"
         if grep -q 'downloadAssets' build.gradle.kts; then
-            ./gradlew --console=plain downloadAssets
+            "$gradlew" --console=plain downloadAssets
         fi
-        ./gradlew --console=plain assemblePlugin
+        "$gradlew" --console=plain assemblePlugin
     )
 done
 echo ""


### PR DESCRIPTION
## What went wrong

The [Build plugin artifacts run](https://github.com/appdevforall/plugin-examples/actions/runs/29428519056/job/87397145231) (manual dispatch, \`plugin: flutter-template\`) failed:

\`\`\`
→ flutter-template
./scripts/update-libs.sh: line 178: ./gradlew: No such file or directory
##[error]Process completed with exit code 127.
\`\`\`

The libs refresh and both CoGo builds succeeded — the failure is only in the plugin build loop. \`scripts/update-libs.sh\` \`cd\`s into each plugin and runs \`./gradlew\`, but **\`flutter-template/\` ships no per-plugin wrapper** — it's the one plugin already migrated to the CLAUDE.md convention of using the repo-root Gradle wrapper (\`cd <plugin> && ../gradlew assemblePlugin\`). So \`./gradlew\` is missing and bash exits 127.

## Fix

Select the wrapper per-plugin in the build loop: use the plugin's \`./gradlew\` when present and executable, otherwise fall back to the repo-root \`\$REPO_ROOT/gradlew\`. Running the root wrapper from inside the plugin dir builds the correct project (Gradle resolves it from the CWD's \`settings.gradle.kts\`).

No other spot needs changing: the CodeOnTheGo-checkout gradlew calls (lines 85/91/98) already use that checkout's own wrapper, and \`build-plugins.yml\` / \`update-libs.yml\` both invoke this script.

## Verification

- \`../gradlew assemblePlugin\` from within \`flutter-template/\` builds \`fluttertemplate.cgp\` ✅
- Wrapper-selection dry-run: \`flutter-template → repo-root gradlew\`, \`random-xkcd → ./gradlew\` (local wrapper still used) ✅
- \`bash -n scripts/update-libs.sh\` clean ✅