### PR TITLE
ADFA-5018 | Open Agent settings from IDE Preferences

### DIFF
--- a/ai-assistant/README.md
+++ b/ai-assistant/README.md
@@ -28,6 +28,8 @@ sibling [`ai-core`](../ai-core/) plugin.
 - Agent tool-loop with per-tool approval dialogs
 - Session persistence
 - Works with either backend exposed by `ai-core` (on-device GGUF or Gemini API)
+- Settings contributed to the IDE's own Preferences via `SettingsExtension`
+  (**Preferences → Configuration → Agent**), and reachable from the chat too
 
 ## Building
 
@@ -47,7 +49,8 @@ The build resolves `plugin-api.jar` from the repo-root `../libs/`.
 1. Build and install **`ai-core` first** (see [`../ai-core/README.md`](../ai-core/README.md)).
 2. Build this plugin, copy `build/plugin/ai-assistant.cgp` to the device.
 3. Install via CodeOnTheGo's Plugin Manager, then restart the IDE.
-4. Open **AI Settings** to pick a local model or configure a Gemini API key.
+4. Open **Preferences → Configuration → Agent** to pick a local model or configure a
+   Gemini API key. The Agent tab's overflow menu opens the same screen.
 
 ## Gemini key setup (ADFA-2709)
 
@@ -92,7 +95,9 @@ check decide.
 
 - `AiAssistantPlugin.kt` — plugin entry point / lifecycle
 - `fragments/ChatFragment.kt`, `viewmodel/ChatViewModel.kt` — chat UI + state
-- `fragments/AiSettingsFragment.kt`, `viewmodel/AiSettingsViewModel.kt` — model/backend config
+- `fragments/AiSettingsFragment.kt`, `viewmodel/AiSettingsViewModel.kt` — model/backend
+  config; mounted full-screen by the host's `PluginScreenActivity`, so it carries its own
+  app bar and closes by finishing that activity
 - `gemini/` — Gemini key onboarding + pre-save verification
 - `tool/` — the agent tool-loop (executor, router, per-tool handlers, approval)
 
@@ -103,7 +108,7 @@ check decide.
   this plugin's private `SharedPreferences` (`AgentSettings`), as
   `enc:v1:` + base64(iv‖ciphertext). A copied prefs file — root, `adb backup`,
   forensic dump — is useless without this device's Keystore. Remove the key any
-  time from **AI Settings** (or `clearGeminiApiKey()`).
+  time from **Preferences → Configuration → Agent** (or `clearGeminiApiKey()`).
   - A key stored before this plugin encrypted them is still plaintext on disk;
     it is re-encrypted in place the first time it's read
     (`SecureApiKeyStore.readAndMigrate`), so no user action is needed.

--- a/ai-assistant/ai-assistant.html
+++ b/ai-assistant/ai-assistant.html
@@ -74,7 +74,8 @@
       diff to accept, decline, or send back with a correction, and lands in the
       editor buffer (undoable with Ctrl+Z) when the file is open.</li>
     <li><b>Dual inference backends</b> — fully offline on-device inference, or
-      Gemini in the cloud, selectable in Settings.</li>
+      Gemini in the cloud, selectable under <b>Preferences &rarr; Configuration
+      &rarr; Agent</b>.</li>
     <li><b>Direct commands</b> — explicit requests like "open MainActivity.java",
       "list files", "read &lt;file&gt;" or "search &lt;query&gt;" run the tool
       directly (resolving a bare filename to its path), so they work reliably on
@@ -114,8 +115,9 @@ cd ../ai-assistant &amp;&amp; ./gradlew assemblePlugin</code></pre>
   <ul>
     <li>Copy both <code>.cgp</code> files to the device and install via the CoGo
       Plugin Manager — <b>AI Core first</b>, then AI Assistant. Restart the IDE.</li>
-    <li>Open <b>Settings</b> and either select a <code>.gguf</code> model (Local)
-      or set up a Gemini API key (Gemini).</li>
+    <li>Open <b>Preferences &rarr; Configuration &rarr; Agent</b> — or the Agent
+      tab's overflow menu, which opens the same screen — and either select a
+      <code>.gguf</code> model (Local) or set up a Gemini API key (Gemini).</li>
     <li>For Gemini, tap <b>Get API Key</b> to open Google AI Studio in your
       browser — it creates the underlying Cloud project for you, so no Google
       Cloud console visit is needed. Copy the key, paste it into the key field,

--- a/ai-assistant/src/main/AndroidManifest.xml
+++ b/ai-assistant/src/main/AndroidManifest.xml
@@ -28,11 +28,11 @@
 
         <meta-data
             android:name="plugin.min_ide_version"
-            android:value="26.17" />
+            android:value="26.32" />
 
         <meta-data
             android:name="plugin.max_ide_version"
-            android:value="26.31" />
+            android:value="26.99" />
 
         <!-- Number of editor tabs contributed via getEditorTabs() (the "Agent" tab) -->
         <meta-data

--- a/ai-assistant/src/main/assets/docs/index.html
+++ b/ai-assistant/src/main/assets/docs/index.html
@@ -40,12 +40,18 @@
   your project through an approval-gated tool loop. Inference is served by the
   companion <b>AI Core</b> plugin, so install <b>AI Core first</b>.</p>
 
+  <h2>Where the settings live</h2>
+  <p>The backend, the model and your Gemini API key are all configured on one
+  screen, reached from <b>Preferences → Configuration → Agent</b>. The same screen
+  opens from the Agent tab's overflow menu (<b>Settings</b>), so you do not have to
+  leave the chat to change something. Every setting saves as you change it.</p>
+
   <h2>Choosing a backend</h2>
   <ul>
     <li><b>Local (on-device)</b> — runs a <code>.gguf</code> model via
-      llama.cpp. Open <b>Settings</b>, pick a model file from your Downloads
-      folder. Nothing leaves the device.</li>
-    <li><b>Gemini (cloud)</b> — enter a Gemini API key in <b>Settings</b>; see
+      llama.cpp. Open <b>Preferences → Configuration → Agent</b> and pick a model
+      file from your Downloads folder. Nothing leaves the device.</li>
+    <li><b>Gemini (cloud)</b> — enter a Gemini API key on the same screen; see
       <i>Getting a Gemini API key</i> below. Prompts and any file contents the
       agent reads are sent to Google over HTTPS.</li>
   </ul>
@@ -86,8 +92,9 @@
   <b>aistudio.google.com/apikey</b>, and Google AI Studio sets up the underlying
   Cloud project for you the first time you accept its terms.</p>
   <ol>
-    <li>In <b>Settings</b> with the <b>Gemini</b> backend selected, tap
-      <b>Get API Key</b>. Your normal browser opens at AI Studio.</li>
+    <li>On the <b>Agent</b> settings screen with the <b>Gemini</b> backend
+      selected, tap <b>Get API Key</b>. Your normal browser opens at AI
+      Studio.</li>
     <li>Sign in with your Google account <i>in the browser</i> and tap
       <b>Create API key</b>. This plugin never sees your Google password.</li>
     <li>Copy the key Google shows you, return to the IDE and paste it into the
@@ -130,7 +137,8 @@
   <p>The key is encrypted with AES/GCM under a hardware-backed Android Keystore
   secret, and only the ciphertext is written to the plugin's private storage —
   a copied preferences file is useless without this device's Keystore. Clear it
-  any time from <b>Settings</b>. If the Keystore entry is ever lost — clearing the
+  any time from <b>Preferences → Configuration → Agent</b>. If the Keystore entry
+  is ever lost — clearing the
   app's data, for example — the stored key can no longer be read and will need to
   be entered again; tapping <b>Edit</b> tells you when that has happened.</p>
 
@@ -139,7 +147,8 @@
     <li><b>Retry</b> appears on a message whose reply failed, and re-sends the
       same prompt with the same attached files rather than adding a new one.</li>
     <li><b>Open AI Settings</b> appears instead when the agent has not been
-      configured yet — no local model chosen, or no Gemini key saved.</li>
+      configured yet — no local model chosen, or no Gemini key saved. It opens the
+      <b>Agent</b> settings screen directly.</li>
     <li><b>System log</b> rows are collapsed records of the agent's internal
       steps: tools run, files touched, backend errors. Tap the header to expand
       one. They are saved with the session but are not sent to the model.</li>
@@ -150,7 +159,8 @@
   <h2>Troubleshooting</h2>
   <ul>
     <li><b>"No model configured"</b> — select a <code>.gguf</code> file (Local)
-      or set an API key (Gemini) in Settings.</li>
+      or set an API key (Gemini) under <b>Preferences → Configuration →
+      Agent</b>.</li>
     <li><b>Gemini errors</b> — check the API key, network connection, and quota.
       Re-tapping <b>Save</b> on the key re-runs the live check and tells you which
       of the three it is.</li>

--- a/ai-assistant/src/main/kotlin/com/itsaky/androidide/plugins/aiassistant/AiAssistantPlugin.kt
+++ b/ai-assistant/src/main/kotlin/com/itsaky/androidide/plugins/aiassistant/AiAssistantPlugin.kt
@@ -1,21 +1,25 @@
 package com.itsaky.androidide.plugins.aiassistant
 
+import android.content.res.Resources
 import com.itsaky.androidide.plugins.IPlugin
 import com.itsaky.androidide.plugins.PluginContext
 import com.itsaky.androidide.plugins.extensions.UIExtension
 import com.itsaky.androidide.plugins.extensions.DocumentationExtension
 import com.itsaky.androidide.plugins.extensions.MenuItem
+import com.itsaky.androidide.plugins.extensions.PluginSettingsEntry
 import com.itsaky.androidide.plugins.extensions.PluginTooltipButton
 import com.itsaky.androidide.plugins.extensions.PluginTooltipEntry
+import com.itsaky.androidide.plugins.extensions.SettingsExtension
 import com.itsaky.androidide.plugins.extensions.TabItem
 import com.itsaky.androidide.plugins.services.IdeProjectService
 import com.itsaky.androidide.plugins.services.LlmInferenceService
 import com.itsaky.androidide.plugins.services.SharedServices
+import com.itsaky.androidide.plugins.aiassistant.fragments.AiSettingsFragment
 import com.itsaky.androidide.plugins.aiassistant.fragments.ChatFragment
 import com.itsaky.androidide.plugins.aiassistant.tool.handlers.PathGuard
 import java.io.File
 
-class AiAssistantPlugin : IPlugin, UIExtension, DocumentationExtension {
+class AiAssistantPlugin : IPlugin, UIExtension, DocumentationExtension, SettingsExtension {
 
     private lateinit var context: PluginContext
     private var llmService: LlmInferenceService? = null
@@ -52,7 +56,7 @@ class AiAssistantPlugin : IPlugin, UIExtension, DocumentationExtension {
         const val TOOLTIP_TAG_MESSAGE_OPEN_SETTINGS = "agent_message_open_settings"
         const val TOOLTIP_TAG_SYSTEM_LOG = "agent_system_log"
 
-        // Tags for the interactive controls on the AI Settings dialog (see AiSettingsFragment).
+        // Tags for the interactive controls on the AI Settings screen (see AiSettingsFragment).
         const val TOOLTIP_TAG_SETTINGS_BACK = "ai_settings_back"
         const val TOOLTIP_TAG_SETTINGS_BACKEND = "ai_settings_backend"
         const val TOOLTIP_TAG_SETTINGS_LOCAL_MODEL = "ai_settings_local_model"
@@ -139,6 +143,38 @@ class AiAssistantPlugin : IPlugin, UIExtension, DocumentationExtension {
 
     override fun getMainMenuItems(): List<MenuItem> = emptyList()
 
+    // --- SettingsExtension: the Agent row in Preferences -> Configuration ---
+
+    /**
+     * One row, opening the same [AiSettingsFragment] the Agent chat's own shortcuts open. The host
+     * calls this every time Preferences is built, so it stays cheap and free of side effects.
+     */
+    override fun getSettingsEntries(): List<PluginSettingsEntry> = listOf(
+        PluginSettingsEntry(
+            id = "agent_settings",
+            title = string(R.string.pref_agent_title, "Agent"),
+            summary = string(R.string.pref_agent_summary, "AI backend, model and API key"),
+            fragmentClassName = AiSettingsFragment::class.java.name
+        )
+    )
+
+    /**
+     * Resolve [resId] against this plugin's own resources — [PluginContext.androidContext] is
+     * plugin-scoped, so the plugin's strings.xml applies.
+     *
+     * @param fallback returned when the context is missing or the lookup fails; the host may build
+     *   Preferences either side of a lifecycle edge and must never see an exception from here
+     */
+    private fun string(resId: Int, fallback: String): String =
+        try {
+            pluginContext?.androidContext?.getString(resId) ?: fallback
+        } catch (e: Resources.NotFoundException) {
+            pluginContext?.logger?.warn("AiAssistantPlugin: settings row string $resId missing", e)
+            fallback
+        }
+
+    // --- DocumentationExtension: three-tier in-IDE help for the Agent tab ---
+
     /**
      * Three-tier in-IDE help: `summary` is Tier 1 (long-press one-liner), `detail` is Tier 2 (HTML
      * behind "See More") and `buttons[].uri` is Tier 3 (the offline page under assets/docs/).
@@ -157,9 +193,10 @@ class AiAssistantPlugin : IPlugin, UIExtension, DocumentationExtension {
                 <p>Backends:</p>
                 <ul>
                   <li><b>Local</b> — on-device inference via llama.cpp (select a
-                      <code>.gguf</code> model in Settings).</li>
-                  <li><b>Gemini</b> — Google's cloud API (needs an API key in
-                      Settings; requests leave the device over HTTPS).</li>
+                      <code>.gguf</code> model under <b>Preferences &rarr;
+                      Configuration &rarr; Agent</b>).</li>
+                  <li><b>Gemini</b> — Google's cloud API (needs an API key on the
+                      same screen; requests leave the device over HTTPS).</li>
                 </ul>
                 <p>File-editing tools are confined to the current project and
                 ask for approval before writing.</p>
@@ -222,12 +259,14 @@ class AiAssistantPlugin : IPlugin, UIExtension, DocumentationExtension {
         ),
         PluginTooltipEntry(
             tag = TOOLTIP_TAG_CHAT_MENU,
-            summary = "Agent menu: open AI Settings or start a new chat session.",
+            summary = "Agent menu: open the Agent settings or start a new chat session.",
             detail = """
                 <p>Opens the Agent's overflow menu:</p>
                 <ul>
-                  <li><b>Settings</b> — choose the backend (Local or Gemini),
-                      pick a model and manage your Gemini API key.</li>
+                  <li><b>Settings</b> — a shortcut to the same screen as
+                      <b>Preferences &rarr; Configuration &rarr; Agent</b>: choose
+                      the backend (Local or Gemini), pick a model and manage your
+                      Gemini API key.</li>
                   <li><b>Clear chat</b> — starts a fresh session. The previous
                       conversation stays on disk in the plugin's own storage.</li>
                 </ul>
@@ -343,7 +382,7 @@ class AiAssistantPlugin : IPlugin, UIExtension, DocumentationExtension {
                 <p><b>Retry</b> re-sends the same prompt with the same attached
                 context files; it does not add a new message to the conversation.
                 If it keeps failing, check the backend and model under
-                <b>Settings</b>.</p>
+                <b>Preferences &rarr; Configuration &rarr; Agent</b>.</p>
             """.trimIndent(),
             buttons = listOf(
                 PluginTooltipButton(description = "AI Assistant guide", uri = "index.html", order = 0)
@@ -351,13 +390,14 @@ class AiAssistantPlugin : IPlugin, UIExtension, DocumentationExtension {
         ),
         PluginTooltipEntry(
             tag = TOOLTIP_TAG_MESSAGE_OPEN_SETTINGS,
-            summary = "Jump to AI Settings to fix the problem this message reports.",
+            summary = "Jump to the Agent settings to fix the problem this message reports.",
             detail = """
                 <p>Shown when the agent could not run because it is not configured
                 yet — no local model selected, or no Gemini API key saved.</p>
-                <p>Opens <b>AI Settings</b> so you can choose a backend, pick a
-                <code>.gguf</code> model or enter a key, then return and send your
-                message again.</p>
+                <p>Opens the <b>Agent</b> settings screen — the same one under
+                <b>Preferences &rarr; Configuration &rarr; Agent</b> — so you can
+                choose a backend, pick a <code>.gguf</code> model or enter a key,
+                then return and send your message again.</p>
             """.trimIndent(),
             buttons = listOf(
                 PluginTooltipButton(description = "AI Assistant guide", uri = "index.html", order = 0)
@@ -380,11 +420,12 @@ class AiAssistantPlugin : IPlugin, UIExtension, DocumentationExtension {
         ),
         PluginTooltipEntry(
             tag = TOOLTIP_TAG_SETTINGS_BACK,
-            summary = "Close AI Settings and return to the Agent chat.",
+            summary = "Close the Agent settings and go back where you came from.",
             detail = """
-                <p>Closes this dialog. Every setting here is saved as you change
-                it, so there is nothing to confirm — the Agent picks up the new
-                backend and model as soon as you return.</p>
+                <p>Closes this screen, returning to Preferences or to the Agent
+                chat depending on how you opened it. Every setting here is saved as
+                you change it, so there is nothing to confirm — the Agent picks up
+                the new backend and model as soon as you return.</p>
             """.trimIndent(),
             buttons = listOf(
                 PluginTooltipButton(description = "AI Assistant guide", uri = "index.html", order = 0)

--- a/ai-assistant/src/main/kotlin/com/itsaky/androidide/plugins/aiassistant/fragments/AiSettingsFragment.kt
+++ b/ai-assistant/src/main/kotlin/com/itsaky/androidide/plugins/aiassistant/fragments/AiSettingsFragment.kt
@@ -16,7 +16,7 @@ import android.view.WindowManager
 import android.widget.*
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.DrawableRes
-import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -37,12 +37,12 @@ import java.util.Date
 import java.util.Locale
 import kotlin.math.roundToInt
 
-class AiSettingsFragment : DialogFragment() {
-
-    companion object {
-        /** FragmentResult key signalling the chat screen that settings were closed. */
-        const val RESULT_SETTINGS_CLOSED = "ai_settings_closed"
-    }
+/**
+ * The Agent settings screen, reached from Preferences → Configuration → Agent and from the Agent
+ * chat's own shortcuts. The host mounts it full-screen in PluginScreenActivity, which provides no
+ * toolbar, so this fragment brings its own app bar and closes by finishing that activity.
+ */
+class AiSettingsFragment : Fragment() {
 
     private lateinit var viewModel: AiSettingsViewModel
     private lateinit var settingsToolbar: LinearLayout
@@ -102,15 +102,17 @@ class AiSettingsFragment : DialogFragment() {
         }
 
     /**
-     * Route inflation through the host so the dialog's views resolve against a Context whose
+     * Route inflation through the host so this screen's views resolve against a Context whose
      * Configuration tracks the IDE's day/night setting (DayNight PluginTheme + values-night/
-     * colors). Replaces the old cloneInContext(pluginContext), which pinned the UI to light mode.
+     * colors); the raw fragment inflater pins the screen to light mode.
+     *
+     * Overridden here rather than applied inside [onCreateView] so that `layoutInflater` itself is
+     * the themed one — the backend panes swapped into [backendSpecificContainer] and anything else
+     * reaching for it get the theme for free. Same shape as ChatFragment.
      */
     override fun onGetLayoutInflater(savedInstanceState: Bundle?): LayoutInflater {
         val inflater = super.onGetLayoutInflater(savedInstanceState)
-        return com.itsaky.androidide.plugins.base.PluginFragmentHelper.getPluginInflater(
-            com.itsaky.androidide.plugins.aiassistant.AiAssistantPlugin.PLUGIN_ID, inflater
-        )
+        return PluginFragmentHelper.getPluginInflater(AiAssistantPlugin.PLUGIN_ID, inflater)
     }
 
     override fun onCreateView(
@@ -138,16 +140,8 @@ class AiSettingsFragment : DialogFragment() {
     override fun onDestroyView() {
         // Drops the captured Gemini pane views along with the callback.
         onGeminiPaneResume = null
+        setSecureWindow(false)
         super.onDestroyView()
-    }
-
-    override fun onDismiss(dialog: android.content.DialogInterface) {
-        super.onDismiss(dialog)
-        // This is a dialog, so the chat screen behind it never gets onResume when we close.
-        // Signal it to re-resolve the selected backend (routing + availability + label).
-        if (isAdded) {
-            parentFragmentManager.setFragmentResult(RESULT_SETTINGS_CLOSED, Bundle.EMPTY)
-        }
     }
 
     private fun initializeViewModel() {
@@ -170,8 +164,8 @@ class AiSettingsFragment : DialogFragment() {
 
     private fun setupToolbar() {
         backButton.setOnClickListener {
-            // Close the dialog
-            dismiss()
+            // This screen owns the whole activity, so closing it means finishing that activity.
+            requireActivity().finish()
         }
         wireTooltip(backButton, AiAssistantPlugin.TOOLTIP_TAG_SETTINGS_BACK)
     }
@@ -209,8 +203,8 @@ class AiSettingsFragment : DialogFragment() {
         // The Gemini pane's views are about to go; its resume callback must not outlive them.
         onGeminiPaneResume = null
 
-        // Reuse the fragment's theme-aware inflater (routed through getPluginInflater) so these
-        // sub-layouts follow the IDE day/night theme like the rest of the dialog.
+        // layoutInflater is the theme-aware one (see onGetLayoutInflater), so these sub-layouts
+        // follow the IDE day/night theme like the rest of the screen.
         when (backend) {
             AiBackend.LOCAL_LLM -> {
                 val localLlmView = layoutInflater
@@ -608,15 +602,15 @@ class AiSettingsFragment : DialogFragment() {
     }
 
     /**
-     * Add or clear [WindowManager.LayoutParams.FLAG_SECURE] on this dialog's window.
+     * Add or clear [WindowManager.LayoutParams.FLAG_SECURE] on the host activity's window.
      *
      * Set while the key is in clear text, or screenshots and the recents thumbnail would capture
-     * it. A null window on the first call is safe: the initial state is masked.
+     * it. Cleared in [onDestroyView], since the window outlives this fragment's view.
      *
      * @param secure true to block capture, false to allow it again
      */
     private fun setSecureWindow(secure: Boolean) {
-        val window = dialog?.window ?: return
+        val window = activity?.window ?: return
         if (secure) {
             window.setFlags(
                 WindowManager.LayoutParams.FLAG_SECURE,

--- a/ai-assistant/src/main/kotlin/com/itsaky/androidide/plugins/aiassistant/fragments/ChatFragment.kt
+++ b/ai-assistant/src/main/kotlin/com/itsaky/androidide/plugins/aiassistant/fragments/ChatFragment.kt
@@ -25,6 +25,7 @@ import com.itsaky.androidide.plugins.aiassistant.viewmodel.ChatViewModel
 import com.itsaky.androidide.plugins.base.PluginFragmentHelper
 import com.itsaky.androidide.plugins.services.IdeProjectService
 import com.itsaky.androidide.plugins.services.IdeTooltipService
+import com.itsaky.androidide.plugins.services.IdeUIService
 import io.noties.markwon.Markwon
 import kotlinx.coroutines.launch
 import java.io.File
@@ -115,14 +116,6 @@ class ChatFragment : Fragment(), ApprovalDialogFragment.Host {
         setupBackendIndicator()
         observeViewModel()
 
-        // Settings is a DialogFragment, so onResume does not fire when it closes.
-        parentFragmentManager.setFragmentResultListener(
-            AiSettingsFragment.RESULT_SETTINGS_CLOSED, viewLifecycleOwner
-        ) { _, _ ->
-            viewModel.checkBackendAvailability()
-            viewModel.refreshBackendLabel()
-        }
-
         // Check for test prompt from broadcast receiver (E2E testing)
         injectPendingTestPrompt()
     }
@@ -177,7 +170,8 @@ class ChatFragment : Fragment(), ApprovalDialogFragment.Host {
         super.onResume()
         // On becoming visible, so the check runs after every plugin has loaded.
         viewModel.checkBackendAvailability()
-        // Reflect the currently selected backend (updates after returning from settings).
+        // Re-resolve the selected backend here: the settings screen is a separate activity that
+        // fully covers chat, so returning from it always delivers onResume.
         viewModel.refreshBackendLabel()
     }
 
@@ -441,10 +435,24 @@ class ChatFragment : Fragment(), ApprovalDialogFragment.Host {
         imm.hideSoftInputFromWindow(binding.promptInputEdittext.windowToken, 0)
     }
 
+    /**
+     * Open the Agent settings screen — the same one Preferences → Configuration → Agent opens, so
+     * there is one implementation of it. The host mounts it full-screen in PluginScreenActivity;
+     * returning from it gives this fragment a real onResume.
+     */
     private fun openSettingsFragment() {
-        val settingsFragment = AiSettingsFragment()
-        // Show as dialog fragment to avoid overlapping with chat UI
-        settingsFragment.show(parentFragmentManager, "ai_settings")
+        val opened = PluginFragmentHelper.getServiceRegistry(AiAssistantPlugin.PLUGIN_ID)
+            ?.get(IdeUIService::class.java)
+            ?.openPluginScreen(
+                AiAssistantPlugin.PLUGIN_ID,
+                AiSettingsFragment::class.java.name,
+                getString(R.string.pref_agent_title)
+            ) ?: false
+        if (!opened) {
+            AiAssistantPlugin.getContext()?.logger
+                ?.warn("ChatFragment: could not open the Agent settings screen")
+            showInfoSnackbar(getString(R.string.msg_settings_unavailable))
+        }
     }
 
     /**
@@ -457,7 +465,7 @@ class ChatFragment : Fragment(), ApprovalDialogFragment.Host {
         val binding = _binding ?: return
         Snackbar
             .make(binding.root, message, Snackbar.LENGTH_LONG)
-            .setAction("Settings") { openSettingsFragment() }
+            .setAction(getString(R.string.menu_settings)) { openSettingsFragment() }
             .show()
     }
 

--- a/ai-assistant/src/main/res/drawable/ic_arrow_back.xml
+++ b/ai-assistant/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:autoMirrored="true">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8l8,8l1.41,-1.41L7.83,13H20V11z" />
+
+</vector>

--- a/ai-assistant/src/main/res/layout/fragment_ai_settings.xml
+++ b/ai-assistant/src/main/res/layout/fragment_ai_settings.xml
@@ -3,34 +3,36 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="?attr/colorSurface"
     android:orientation="vertical">
 
     <LinearLayout
         android:id="@+id/settings_toolbar"
         android:layout_width="match_parent"
         android:layout_height="?android:attr/actionBarSize"
-        android:orientation="horizontal"
+        android:background="?attr/colorSurface"
         android:gravity="center_vertical"
+        android:orientation="horizontal"
         android:paddingStart="4dp"
-        android:paddingEnd="16dp"
-        android:background="?attr/colorPrimary">
+        android:paddingEnd="16dp">
 
         <ImageButton
             android:id="@+id/toolbar_back_button"
             android:layout_width="48dp"
             android:layout_height="48dp"
             android:background="?android:attr/selectableItemBackgroundBorderless"
-            android:src="@android:drawable/ic_menu_close_clear_cancel"
-            android:tint="?attr/colorOnPrimary"
-            android:contentDescription="Back" />
+            android:contentDescription="@string/cd_settings_back"
+            android:src="@drawable/ic_arrow_back"
+            android:tint="?attr/colorOnSurface" />
 
         <TextView
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
             android:layout_weight="1"
-            android:text="AI Settings"
-            android:textAppearance="?android:attr/textAppearanceLarge"
-            android:textColor="?attr/colorOnPrimary" />
+            android:text="@string/pref_agent_title"
+            android:textAppearance="?attr/textAppearanceTitleLarge"
+            android:textColor="?attr/colorOnSurface" />
     </LinearLayout>
 
     <ScrollView
@@ -46,7 +48,7 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="AI Backend"
+                android:text="@string/label_ai_backend"
                 android:textAppearance="?android:attr/textAppearanceSmall"
                 android:paddingBottom="4dp"/>
 

--- a/ai-assistant/src/main/res/layout/layout_settings_local_llm.xml
+++ b/ai-assistant/src/main/res/layout/layout_settings_local_llm.xml
@@ -9,7 +9,7 @@
         android:id="@+id/engine_status_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Initializing engine..."
+        android:text="@string/engine_initializing"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:layout_marginTop="8dp"
         android:textColor="?android:attr/textColorSecondary"/>
@@ -28,7 +28,7 @@
         android:id="@+id/selected_model_path"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="No model selected"
+        android:text="@string/model_none_selected"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="?android:attr/textColorSecondary"
         android:paddingBottom="8dp"/>
@@ -37,7 +37,7 @@
         android:id="@+id/btn_browse_model"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Browse for Model File" />
+        android:text="@string/btn_browse_model" />
 
     <Button
         android:id="@+id/loadSavedButton"
@@ -45,7 +45,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
         android:enabled="false"
-        android:text="Load from saved"
+        android:text="@string/btn_load_saved_model"
         tools:enabled="true" />
 
     <LinearLayout
@@ -58,7 +58,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Optional SHA-256 (for verification)"
+            android:text="@string/label_local_model_sha"
             android:textAppearance="?android:attr/textAppearanceSmall"
             android:paddingBottom="4dp"/>
 
@@ -67,7 +67,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="textNoSuggestions"
-            android:hint="SHA-256 hash"
+            android:hint="@string/hint_local_model_sha"
             android:maxLines="1" />
     </LinearLayout>
 
@@ -75,7 +75,7 @@
         android:id="@+id/switch_simple_local_prompt"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Use simple local prompt"
+        android:text="@string/label_use_simple_local_prompt"
         android:checked="true"
         android:layout_marginTop="16dp" />
 

--- a/ai-assistant/src/main/res/values/strings.xml
+++ b/ai-assistant/src/main/res/values/strings.xml
@@ -102,8 +102,15 @@
     <string name="sender_system">System</string>
     <string name="sender_tool">Tool</string>
 
+    <!-- Preferences row (Preferences → Configuration → Agent) -->
+    <string name="pref_agent_title">Agent</string>
+    <string name="pref_agent_summary">AI backend, model and API key</string>
+    <string name="msg_settings_unavailable">Couldn\'t open Agent settings. Open them from Preferences → Configuration → Agent.</string>
+
     <!-- Settings -->
     <string name="settings_title">AI Settings</string>
+    <string name="cd_settings_back">Close settings</string>
+    <string name="label_ai_backend">AI Backend</string>
     <string name="cd_show_api_key">Show API key</string>
     <string name="cd_hide_api_key">Hide API key</string>
     <string name="hint_gemini_api_key">Enter your Gemini API key</string>
@@ -174,6 +181,14 @@
     <string name="model_loaded">✅ Model loaded: %s</string>
     <string name="model_load_error">❌ Error: %s</string>
     <string name="model_loading_toast">Loading model…</string>
+
+    <!-- Settings: local model pane -->
+    <string name="model_none_selected">No model selected</string>
+    <string name="btn_browse_model">Browse for Model File</string>
+    <string name="btn_load_saved_model">Load from saved</string>
+    <string name="label_local_model_sha">Optional SHA-256 (for verification)</string>
+    <string name="hint_local_model_sha">SHA-256 hash</string>
+    <string name="label_use_simple_local_prompt">Use simple local prompt</string>
 
     <!-- Settings: models -->
     <string name="label_gemini_model">Gemini Model</string>

--- a/ai-core/src/main/AndroidManifest.xml
+++ b/ai-core/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
 
         <meta-data
             android:name="plugin.max_ide_version"
-            android:value="26.31" />
+            android:value="26.99" />
 
         <meta-data
             android:name="plugin.permissions"


### PR DESCRIPTION
## Description

### **What**: 
Migrated the AI Agent's settings from a floating chat dialog to a full-screen view accessible directly from the IDE's Preferences, while retaining the existing in-chat shortcut.


### **How**:
- Implemented `SettingsExtension` in `AiAssistantPlugin.kt` to inject the Agent settings row under **Preferences → Configuration → Agent**.
- Converted `AiSettingsFragment` from a `DialogFragment` to a standard `Fragment` so it can be mounted full-screen by the host's `PluginScreenActivity`.
- Updated `ChatFragment.kt` to launch the settings via `IdeUIService.openPluginScreen()` instead of displaying a local dialog fragment.
- Updated UI layouts (`fragment_ai_settings.xml`) to match standard Preferences styling, including theme-aware backgrounds and a back arrow replacing the close button.
- Extracted hardcoded layout strings to `strings.xml` for proper localization and updated documentation references.

### **Why**:
To make AI configuration discoverable for users configuring the IDE before opening a project, removing a dead end when the agent fails due to missing keys, and unifying the settings UI into a single, consistent implementation.

## Details

- **UI Changes**: The settings screen now uses standard IDE header colors, a back arrow (`ic_arrow_back.xml`), and standard title placement. It fully respects the IDE's light and dark themes via `PluginFragmentHelper`.

- **Logic Changes**: The back button now finishes the host activity instead of dismissing a dialog. Lifecycle management in `ChatFragment` now relies on the standard `onResume()` callback rather than custom fragment result listeners to refresh backend availability.

https://github.com/user-attachments/assets/b9edec34-e6a9-45f7-bfd1-90c7ef4bab30

## Ticket

[ADFA-5018](https://appdevforall.atlassian.net/browse/ADFA-5018)

[ADFA-5018]: https://appdevforall.atlassian.net/browse/ADFA-5018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ