### PR TITLE
Fail fast when the push token cannot write to this repo

### DIFF
--- a/.github/workflows/update-libs.yml
+++ b/.github/workflows/update-libs.yml
@@ -18,9 +18,40 @@ jobs:
         uses: actions/checkout@v4
         with:
           # PAT from a repo admin so the libs/ push bypasses the main ruleset.
-          # Falls back to GITHUB_TOKEN if the secret is unset (push will then
-          # be blocked by the ruleset, which is the safe default).
+          # A fine-grained PAT must use the organization as its resource owner,
+          # not a personal account, or every push returns 403. The next step
+          # checks this. GITHUB_TOKEN is only a fallback to keep checkout
+          # working; it cannot bypass the ruleset, so the check rejects it.
           token: ${{ secrets.ADMIN_PERSONAL_ACCESS_TOKEN || github.token }}
+
+      # The build below takes ~30 minutes. Without this guard, a token that
+      # cannot write to this repo throws all of that away at "Commit updated
+      # jars". Check the token first so the run fails in seconds instead.
+      - name: Verify the push token
+        env:
+          ADMIN_PAT: ${{ secrets.ADMIN_PERSONAL_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ secrets.ADMIN_PERSONAL_ACCESS_TOKEN || github.token }}
+        run: |
+          org="${GITHUB_REPOSITORY%%/*}"
+
+          if [ -z "$ADMIN_PAT" ]; then
+            echo "::error::ADMIN_PERSONAL_ACCESS_TOKEN is not set. GITHUB_TOKEN cannot bypass the ${org} main ruleset, so the push would fail."
+            exit 1
+          fi
+
+          if ! repo=$(gh api "repos/${GITHUB_REPOSITORY}" 2>/dev/null); then
+            echo "::error::The token cannot see ${GITHUB_REPOSITORY}. A fine-grained PAT must use resource owner '${org}' (the organization). A token owned by a personal account cannot reach ${org} repositories."
+            exit 1
+          fi
+
+          who=$(gh api user --jq .login 2>/dev/null || echo '(unknown)')
+          push=$(printf '%s' "$repo" | jq -r '.permissions.push // false')
+          echo "Token identity: ${who}. Push permission: ${push}."
+
+          if [ "$push" != "true" ]; then
+            echo "::error::The token authenticates as '${who}' but cannot write to ${GITHUB_REPOSITORY}. Grant it 'Contents: Read and write' with resource owner '${org}'."
+            exit 1
+          fi
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Problem

`Update libs from CodeOnTheGo` builds both jars and all 27 plugins, then pushes `libs/` at the **last** step. When `ADMIN_PERSONAL_ACCESS_TOKEN` cannot write to this repo, that push returns 403 and the whole run is wasted.

Three consecutive runs failed this way, each after ~28 minutes of building:

| Run | Date | Failed step |
|---|---|---|
| [31066007779](https://github.com/appdevforall/plugin-examples/actions/runs/31066007779) | 2026-08-06 | Commit updated jars |
| 30458965735 | 2026-07-29 | Commit updated jars |
| 30407097223 | 2026-07-28 | Commit updated jars |

```
remote: Permission to appdevforall/plugin-examples.git denied to hal-eisen-adfa.
fatal: unable to access 'https://github.com/appdevforall/plugin-examples/': error: 403
```

## Root cause

The **resource owner** of the fine-grained PAT is the personal account `hal-eisen-adfa`, which owns only 2 repositories. `plugin-examples` is owned by the **organization** `appdevforall`, so it is outside the token's scope — regardless of which permissions the token grants. This is also why GitHub reports the token as "never used": no request was ever authorized.

The account itself is fine. `hal-eisen-adfa` has `admin`/`push` on the repo and is an explicit bypass actor (`bypass_mode: always`) on the `main` ruleset.

**The secret still needs replacing** with a PAT whose resource owner is `appdevforall`, granting `Contents: Read and write` + `Metadata: Read`. This PR does not fix that; it makes the failure cheap and self-explaining.

## Change

A `Verify the push token` step immediately after checkout. It fails in seconds instead of ~28 minutes, and names the likely cause.

Tested against the live API, all three paths:

- secret unset → `::error::ADMIN_PERSONAL_ACCESS_TOKEN is not set...`
- token cannot see the repo → `::error::...must use resource owner 'appdevforall' (the organization)...`
- good token → `Token identity: hal-eisen-adfa. Push permission: true.` exit 0

## Limitation

This proves the token can write repo **contents**. It does not prove the identity can bypass the `main` ruleset — a separate condition, satisfied today because the account is a bypass actor.

Secrets are passed via `env:`, and no `github.event.*` input is interpolated, so there is no injection surface.