### PR TITLE
ADFA-3070 | Fix agent chat unscrollable in landscape

### DIFF
--- a/ai-assistant/src/main/kotlin/com/itsaky/androidide/plugins/aiassistant/fragments/ChatFragment.kt
+++ b/ai-assistant/src/main/kotlin/com/itsaky/androidide/plugins/aiassistant/fragments/ChatFragment.kt
@@ -1,17 +1,22 @@
 package com.itsaky.androidide.plugins.aiassistant.fragments
 
+import android.content.res.Configuration
+import android.graphics.Rect
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.doOnAttach
 import androidx.core.view.isVisible
-import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.chip.Chip
 import com.google.android.material.snackbar.Snackbar
 import com.itsaky.androidide.plugins.PluginContext
@@ -21,6 +26,7 @@ import com.itsaky.androidide.plugins.aiassistant.R
 import com.itsaky.androidide.plugins.aiassistant.adapters.ChatAdapter
 import com.itsaky.androidide.plugins.aiassistant.databinding.FragmentChatBinding
 import com.itsaky.androidide.plugins.aiassistant.models.AgentState
+import com.itsaky.androidide.plugins.aiassistant.models.isRunning
 import com.itsaky.androidide.plugins.aiassistant.viewmodel.ChatViewModel
 import com.itsaky.androidide.plugins.base.PluginFragmentHelper
 import com.itsaky.androidide.plugins.services.IdeProjectService
@@ -48,6 +54,11 @@ class ChatFragment : Fragment(), ApprovalDialogFragment.Host {
     private lateinit var chatAdapter: ChatAdapter
     private lateinit var markwon: Markwon
     private val contextFiles = mutableListOf<File>()
+
+    private var composer: ComposerAutoHideController? = null
+
+    /** The message list's layout-declared padding, before any cutout inset is added. */
+    private val basePadding = Rect()
 
     private val tooltipService: IdeTooltipService? by lazy {
         try {
@@ -98,7 +109,15 @@ class ChatFragment : Fragment(), ApprovalDialogFragment.Host {
         }
         super.onDestroyView()
         viewModel.stopProcessing()
+        composer?.detach()
+        composer = null
         _binding = null
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        // The process can be killed while backgrounded even though rotation never recreates us.
+        composer?.saveState(outState)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -112,6 +131,8 @@ class ChatFragment : Fragment(), ApprovalDialogFragment.Host {
         setupToolbar()
         setupRecyclerView()
         setupInputArea()
+        setupCutoutPadding()
+        setupComposer(savedInstanceState)
         setupStatusBar()
         setupBackendIndicator()
         observeViewModel()
@@ -226,23 +247,15 @@ class ChatFragment : Fragment(), ApprovalDialogFragment.Host {
     }
 
     private fun setupInputArea() {
-        binding.promptInputEdittext.doAfterTextChanged { text ->
-            binding.sendButton.isEnabled = !text.isNullOrBlank()
-        }
-
         binding.sendButton.setOnClickListener {
-            val currentAgentState = viewModel.agentState.value
-            when (currentAgentState) {
-                is AgentState.Executing, is AgentState.Processing -> {
-                    viewModel.stopProcessing()
-                }
-                else -> {
-                    val message = binding.promptInputEdittext.text?.toString() ?: return@setOnClickListener
-                    if (message.isNotBlank()) {
-                        hideKeyboard()
-                        viewModel.sendMessage(message)
-                        binding.promptInputEdittext.text?.clear()
-                    }
+            if (viewModel.agentState.value.isRunning) {
+                viewModel.stopProcessing()
+            } else {
+                val message = binding.promptInputEdittext.text?.toString() ?: return@setOnClickListener
+                if (message.isNotBlank()) {
+                    composer?.hideKeyboard()
+                    viewModel.sendMessage(message)
+                    binding.promptInputEdittext.text?.clear()
                 }
             }
         }
@@ -258,6 +271,70 @@ class ChatFragment : Fragment(), ApprovalDialogFragment.Host {
         wireTooltip(binding.backendStatusText, AiAssistantPlugin.TOOLTIP_TAG_SETTINGS_BACKEND)
     }
 
+    /**
+     * Records the message list's own padding so the cutout inset is added to it rather than
+     * replacing it, and stays correct however many inset passes the window makes.
+     */
+    private fun setupCutoutPadding() {
+        val list = binding.chatRecyclerView
+        basePadding.set(list.paddingLeft, list.paddingTop, list.paddingRight, list.paddingBottom)
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
+            applyCutoutPadding(insets)
+            insets
+        }
+        // No dispatched insets to read on the first attach, so take them from the window.
+        binding.root.doOnAttach { view ->
+            ViewCompat.getRootWindowInsets(view)?.let(::applyCutoutPadding)
+        }
+    }
+
+    /**
+     * Holds the message list clear of the camera cutout. Portrait puts it in the status bar and
+     * these insets come back zero; landscape moves it onto a side edge, right where message text
+     * would otherwise start. The toolbar and composer keep their own edge-to-edge alignment.
+     */
+    private fun applyCutoutPadding(insets: WindowInsetsCompat) {
+        val binding = _binding ?: return
+        val cutout = insets.getInsets(WindowInsetsCompat.Type.displayCutout())
+        binding.chatRecyclerView.setPadding(
+            basePadding.left + cutout.left,
+            basePadding.top,
+            basePadding.right + cutout.right,
+            basePadding.bottom,
+        )
+    }
+
+    /**
+     * On a short screen the composer folds away so the history gets its height, and a floating
+     * chevron brings it back. Everywhere else the composer stays pinned and the chevron is absent.
+     */
+    private fun setupComposer(savedInstanceState: Bundle?) {
+        val controller = ComposerAutoHideController(
+            binding,
+            viewLifecycleOwner.lifecycleScope,
+            ::wireTooltip,
+        )
+        // The fragment's own Resources, which is the host activity's and tracks rotation.
+        controller.attach(savedInstanceState, resources.configuration)
+        composer = controller
+    }
+
+    /**
+     * EditorActivity handles orientation itself, so rotating never recreates this fragment and an
+     * alternative-resource bucket would stay frozen at the orientation it was inflated in. The one
+     * thing that must track rotation is re-applied here instead.
+     */
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        val binding = _binding ?: return
+        composer?.onConfigurationChanged(newConfig)
+        // Posted so the window has published the rotated cutout before it is read back.
+        binding.root.post {
+            val root = _binding?.root ?: return@post
+            ViewCompat.getRootWindowInsets(root)?.let(::applyCutoutPadding)
+        }
+    }
+
     private fun setupStatusBar() {
         binding.agentStatusContainer.isVisible = false
     }
@@ -266,7 +343,7 @@ class ChatFragment : Fragment(), ApprovalDialogFragment.Host {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.activeBackendLabel.collect { label ->
-                    binding.backendStatusText.text = label
+                    _binding?.backendStatusText?.text = label
                 }
             }
         }
@@ -285,56 +362,54 @@ class ChatFragment : Fragment(), ApprovalDialogFragment.Host {
     private suspend fun observeMessages() {
         android.util.Log.d("ChatFragment", "observeMessages: Starting to collect messages")
         viewModel.messages.collect { messages ->
+            val binding = _binding ?: return@collect
             android.util.Log.d("ChatFragment", "observeMessages: Received ${messages.size} messages")
             messages.forEachIndexed { index, msg ->
                 android.util.Log.d("ChatFragment", "  Message $index: sender=${msg.sender}, text=${msg.text.take(50)}")
             }
             binding.emptyChatView.isVisible = messages.isEmpty()
             android.util.Log.d("ChatFragment", "observeMessages: Calling submitList with ${messages.size} messages")
+            // Sampled before the list changes: streaming re-emits on every token, so scrolling
+            // unconditionally would drag the user back down whenever they scrolled up to read.
+            val stickToBottom = binding.chatRecyclerView.isAtBottom()
             chatAdapter.submitList(messages) {
                 android.util.Log.d("ChatFragment", "observeMessages: submitList callback - scrolling to ${messages.size - 1}")
-                if (messages.isNotEmpty()) {
-                    binding.chatRecyclerView.scrollToPosition(messages.size - 1)
+                if (stickToBottom && messages.isNotEmpty()) {
+                    // Null after onDestroyView: submitList posts this callback.
+                    _binding?.chatRecyclerView?.scrollToPosition(messages.lastIndex)
                 }
             }
         }
     }
 
+    /** True while the newest message is fully visible, i.e. the user is not reading back. */
+    private fun RecyclerView.isAtBottom(): Boolean = !canScrollVertically(1)
+
     private suspend fun observeAgentState() {
         viewModel.agentState.collect { state ->
+            val binding = _binding ?: return@collect
             when (state) {
-                is AgentState.Idle -> {
-                    binding.agentStatusContainer.isVisible = false
-                    binding.sendButton.isEnabled = true
-                    binding.sendButton.text = getString(R.string.send)
-                }
+                is AgentState.Idle -> binding.agentStatusContainer.isVisible = false
                 is AgentState.Executing -> {
                     binding.agentStatusContainer.isVisible = true
                     binding.agentStatusMessage.text = state.formattedProgress
                     binding.agentStatusTimer.text = state.formattedTiming
-                    binding.sendButton.isEnabled = true
-                    binding.sendButton.text = getString(R.string.btn_stop)
                     viewModel.startStateTimer(state)
                 }
                 is AgentState.Processing -> {
                     binding.agentStatusContainer.isVisible = true
                     binding.agentStatusMessage.text = getString(R.string.generating_response)
                     binding.agentStatusTimer.text = ""
-                    binding.sendButton.isEnabled = true
-                    binding.sendButton.text = getString(R.string.btn_stop)
                 }
                 is AgentState.Error -> {
                     binding.agentStatusContainer.isVisible = false
-                    binding.sendButton.isEnabled = true
-                    binding.sendButton.text = getString(R.string.send)
                     viewModel.stopStateTimer()
                     showErrorSnackbar(state.message)
                 }
-                else -> {
-                    binding.sendButton.isEnabled = false
-                    binding.sendButton.text = getString(R.string.send)
-                }
+                else -> Unit
             }
+            // The composer owns the send/stop button, since Stop is what pins it open.
+            composer?.onAgentRunningChanged(state.isRunning)
         }
     }
 
@@ -386,6 +461,7 @@ class ChatFragment : Fragment(), ApprovalDialogFragment.Host {
         val dialog = FilePickerDialogFragment.newInstance(startPath) { files ->
             addContextFiles(files)
         }
+        composer?.pauseUntilClosed(dialog.lifecycle)
         dialog.show(parentFragmentManager, "file_picker")
     }
 
@@ -407,9 +483,19 @@ class ChatFragment : Fragment(), ApprovalDialogFragment.Host {
                 contextFiles.remove(file)
                 binding.contextChipGroup.removeView(this)
                 viewModel.setContextFiles(contextFiles)
+                updateContextChipVisibility()
             }
         }
         binding.contextChipGroup.addView(chip)
+        updateContextChipVisibility()
+    }
+
+    /**
+     * Keeps the chip row out of the layout while empty; in a short bottom sheet the row it would
+     * otherwise occupy comes straight out of the chat history's height.
+     */
+    private fun updateContextChipVisibility() {
+        binding.contextChipScroll.isVisible = binding.contextChipGroup.childCount > 0
     }
 
     private fun onMessageAction(action: String, message: com.itsaky.androidide.plugins.aiassistant.models.ChatMessage) {
@@ -428,11 +514,6 @@ class ChatFragment : Fragment(), ApprovalDialogFragment.Host {
                 openSettingsFragment()
             }
         }
-    }
-
-    private fun hideKeyboard() {
-        val imm = requireContext().getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as android.view.inputmethod.InputMethodManager
-        imm.hideSoftInputFromWindow(binding.promptInputEdittext.windowToken, 0)
     }
 
     /**

--- a/ai-assistant/src/main/kotlin/com/itsaky/androidide/plugins/aiassistant/fragments/ComposerAutoHideController.kt
+++ b/ai-assistant/src/main/kotlin/com/itsaky/androidide/plugins/aiassistant/fragments/ComposerAutoHideController.kt
@@ -1,0 +1,203 @@
+package com.itsaky.androidide.plugins.aiassistant.fragments
+
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Bundle
+import android.view.View
+import android.view.accessibility.AccessibilityManager
+import android.view.inputmethod.InputMethodManager
+import androidx.core.view.isVisible
+import androidx.core.widget.doAfterTextChanged
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import com.itsaky.androidide.plugins.aiassistant.AiAssistantPlugin
+import com.itsaky.androidide.plugins.aiassistant.R
+import com.itsaky.androidide.plugins.aiassistant.databinding.FragmentChatBinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Owns the composer: whether it is on screen, the idle countdown that folds it away on a short
+ * screen, and the send/stop button it carries. Attached in onViewCreated and detached in
+ * onDestroyView, so nothing it schedules outlives the views it drives.
+ */
+internal class ComposerAutoHideController(
+    binding: FragmentChatBinding,
+    private val scope: CoroutineScope,
+    private val wireTooltip: (View, String) -> Unit,
+) {
+
+    private companion object {
+        const val KEY_COMPOSER_VISIBLE = "composer_visible"
+        const val KEY_COMPOSER_AUTO_HIDE = "composer_auto_hide"
+    }
+
+    private var _binding: FragmentChatBinding? = binding
+
+    private val autoHideMs =
+        binding.root.resources.getInteger(R.integer.chat_composer_auto_hide_ms).toLong()
+    private val compactHeightDp =
+        binding.root.resources.getInteger(R.integer.chat_composer_compact_height_dp)
+
+    /** True only while the screen is too short to keep the composer pinned. */
+    private var autoHide = false
+    private var agentRunning = false
+    private var countdown: Job? = null
+
+    /**
+     * Wires the composer's controls and puts it in the state [savedState] left behind, or open on
+     * a first run. [config] comes from the fragment so this never has to reach for an Activity.
+     */
+    fun attach(savedState: Bundle?, config: Configuration) {
+        val binding = _binding ?: return
+        binding.btnShowComposer.setOnClickListener { setVisible(true) }
+        binding.btnHideComposer.setOnClickListener { setVisible(false) }
+        wireTooltip(binding.btnShowComposer, AiAssistantPlugin.TOOLTIP_TAG_CHAT_INPUT)
+        wireTooltip(binding.btnHideComposer, AiAssistantPlugin.TOOLTIP_TAG_CHAT_INPUT)
+
+        // Focus means the user is mid-thought, so the countdown waits until they step away.
+        binding.promptInputEdittext.setOnFocusChangeListener { _, _ -> onUserInteraction() }
+        binding.promptInputEdittext.doAfterTextChanged { onUserInteraction() }
+
+        autoHide = savedState?.getBoolean(KEY_COMPOSER_AUTO_HIDE) ?: false
+        applyCompactRule(config, visible = savedState?.getBoolean(KEY_COMPOSER_VISIBLE) ?: true)
+    }
+
+    /** Stops the countdown and releases the views; call from onDestroyView. */
+    fun detach() {
+        countdown?.cancel()
+        countdown = null
+        _binding = null
+    }
+
+    /**
+     * Re-evaluates the compact-screen rule after a rotation, always landing on an open composer:
+     * rotating into portrait must never leave it folded away with the tab that would restore it
+     * now gone.
+     */
+    fun onConfigurationChanged(config: Configuration) =
+        applyCompactRule(config, visible = true)
+
+    /**
+     * Switches the trailing button between Send and Stop. Stop lives on that button, so starting a
+     * run opens the composer and holds off the idle countdown until the run ends. Hide still folds
+     * it away on request — that is the user's call, and the reopen tab brings Stop straight back.
+     */
+    fun onAgentRunningChanged(running: Boolean) {
+        agentRunning = running
+        val binding = _binding ?: return
+        val context = binding.root.context
+        if (running) {
+            binding.sendButton.setImageResource(R.drawable.ic_stop)
+            binding.sendButton.contentDescription = context.getString(R.string.desc_stop_agent)
+            // setVisible re-schedules, and canAutoHide already refuses while the agent runs.
+            setVisible(true)
+        } else {
+            binding.sendButton.setImageResource(R.drawable.ic_send)
+            binding.sendButton.contentDescription = context.getString(R.string.desc_send_message)
+            schedule()
+        }
+        updateSendAppearance()
+    }
+
+    /** The composer is in use — text edited, focus moved — so the countdown starts over. */
+    fun onUserInteraction() {
+        updateSendAppearance()
+        schedule()
+    }
+
+    /** Holds the countdown while a modal is up: nothing behind it counts as the user going idle. */
+    fun pauseUntilClosed(lifecycle: Lifecycle) {
+        countdown?.cancel()
+        lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onDestroy(owner: LifecycleOwner) = schedule()
+        })
+    }
+
+    /** Dismisses the soft keyboard raised by the input field. */
+    fun hideKeyboard() {
+        val binding = _binding ?: return
+        val imm = binding.root.context
+            .getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(binding.promptInputEdittext.windowToken, 0)
+    }
+
+    /**
+     * Saves the composer across process death. The auto-hide flag is written too, but
+     * [applyCompactRule] re-derives it on restore: the process can come back in an orientation
+     * other than the one it died in, and the saved flag would describe a screen that is gone.
+     */
+    fun saveState(outState: Bundle) {
+        outState.putBoolean(KEY_COMPOSER_AUTO_HIDE, autoHide)
+        outState.putBoolean(KEY_COMPOSER_VISIBLE, _binding?.inputBarCard?.isVisible ?: true)
+    }
+
+    /**
+     * Turns auto-hide on for short screens only, then settles the composer on [visible]. A folded
+     * composer is asked for, not obeyed: only a compact screen carries the tab that reopens it, so
+     * a taller one always lands open however it was left.
+     */
+    private fun applyCompactRule(config: Configuration, visible: Boolean) {
+        autoHide = config.screenHeightDp < compactHeightDp
+        setVisible(!autoHide || visible)
+    }
+
+    /**
+     * Swaps which of the two tabs is on screen. They are separate views because each belongs on a
+     * different side of the group's top border: the collapsed one stands above it, the expanded
+     * one hangs below it, out of the chat text.
+     */
+    private fun setVisible(visible: Boolean) {
+        val binding = _binding ?: return
+        binding.inputBarCard.isVisible = visible
+        binding.btnShowComposer.isVisible = autoHide && !visible
+        binding.btnHideComposer.isVisible = autoHide && visible
+        if (visible) {
+            schedule()
+        } else {
+            countdown?.cancel()
+            binding.promptInputEdittext.clearFocus()
+            hideKeyboard()
+        }
+    }
+
+    /** Restarts the idle countdown. Safe to call from any interaction; it no-ops when it must. */
+    private fun schedule() {
+        countdown?.cancel()
+        val binding = _binding ?: return
+        if (!autoHide || !binding.inputBarCard.isVisible || !canAutoHide()) return
+        countdown = scope.launch {
+            delay(autoHideMs)
+            setVisible(false)
+        }
+    }
+
+    /**
+     * Guards against folding the composer away at a moment the user would lose something: a draft,
+     * the caret, the Stop button, or a screen reader's only route to the controls.
+     */
+    private fun canAutoHide(): Boolean {
+        val binding = _binding ?: return false
+        if (binding.promptInputEdittext.hasFocus()) return false
+        if (!binding.promptInputEdittext.text.isNullOrBlank()) return false
+        if (isTouchExplorationEnabled()) return false
+        return !agentRunning
+    }
+
+    /** Greys the send icon out on empty input; Stop stays lit because it is always actionable. */
+    private fun updateSendAppearance() {
+        val binding = _binding ?: return
+        binding.sendButton.isActivated =
+            agentRunning || !binding.promptInputEdittext.text.isNullOrBlank()
+    }
+
+    private fun isTouchExplorationEnabled(): Boolean {
+        val context = _binding?.root?.context ?: return false
+        val manager =
+            context.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
+        return manager?.isTouchExplorationEnabled == true
+    }
+}

--- a/ai-assistant/src/main/kotlin/com/itsaky/androidide/plugins/aiassistant/models/AgentState.kt
+++ b/ai-assistant/src/main/kotlin/com/itsaky/androidide/plugins/aiassistant/models/AgentState.kt
@@ -76,3 +76,10 @@ sealed class AgentState {
      */
     data class Error(val message: String) : AgentState()
 }
+
+/**
+ * True while a run is in flight, which is what the composer keys its Stop control off. One
+ * definition so the UI cannot drift from it a state at a time.
+ */
+val AgentState.isRunning: Boolean
+    get() = this is AgentState.Executing || this is AgentState.Processing

--- a/ai-assistant/src/main/res/color/chat_send_tint.xml
+++ b/ai-assistant/src/main/res/color/chat_send_tint.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Send is the composer's only accent, greyed out until there is something to send. Driven by
+  state_activated rather than state_enabled so the button keeps receiving the long-press that
+  opens its tooltip; an empty-input tap is already a no-op in the click handler.
+-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/plugin_primary" android:state_activated="true" />
+    <item android:color="@color/plugin_text_subtle" />
+</selector>

--- a/ai-assistant/src/main/res/drawable/bg_chat_composer.xml
+++ b/ai-assistant/src/main/res/drawable/bg_chat_composer.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  The single rounded field that holds the attach button, the text input and the send button, so the
+  three read as one control. Radius stays fixed as the input grows to its maxLines.
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/plugin_surface" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/plugin_outline_variant" />
+    <corners android:radius="@dimen/chat_composer_corner_radius" />
+</shape>

--- a/ai-assistant/src/main/res/drawable/bg_composer_tab_down.xml
+++ b/ai-assistant/src/main/res/drawable/bg_composer_tab_down.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  The tab shown while the input group is expanded: it hangs below the group's top border, so it is
+  rounded underneath and open along the top, where the border itself closes the shape. Keeping it
+  on this side of the border is what stops it from sitting in the chat text above.
+
+  Filled in the border's own colour rather than the group's, so it reads as a thickened piece of
+  that border. Sharing the group's fill left it invisible apart from its outline.
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:top="-2dp">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/plugin_outline_variant" />
+            <stroke
+                android:width="1dp"
+                android:color="@color/plugin_outline_variant" />
+            <corners
+                android:bottomLeftRadius="9dp"
+                android:bottomRightRadius="9dp"
+                android:topLeftRadius="0dp"
+                android:topRightRadius="0dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/ai-assistant/src/main/res/drawable/bg_composer_tab_up.xml
+++ b/ai-assistant/src/main/res/drawable/bg_composer_tab_up.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  The tab shown while the input group is collapsed: it stands above the group's edge, so it is
+  rounded on top and open along the bottom. The negative bottom inset pushes that side of the
+  stroke past the view's bounds, where it is clipped away.
+
+  The top inset leaves the button's upper part transparent, so a 48dp finger target draws as a 16dp
+  tab. See the note on chat_composer_tab_inset_top before changing it.
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:bottom="-2dp"
+        android:top="@dimen/chat_composer_tab_inset_top">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/plugin_surface_variant" />
+            <stroke
+                android:width="1dp"
+                android:color="@color/plugin_outline_variant" />
+            <corners
+                android:bottomLeftRadius="0dp"
+                android:bottomRightRadius="0dp"
+                android:topLeftRadius="9dp"
+                android:topRightRadius="9dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/ai-assistant/src/main/res/drawable/bg_input_bar.xml
+++ b/ai-assistant/src/main/res/drawable/bg_input_bar.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  The input group's fill plus the 1dp top border the composer tab couples into. Without this line
+  the tab's side strokes end in mid-air and it reads as a chip hovering over the group.
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/plugin_outline_variant" />
+        </shape>
+    </item>
+    <item android:top="1dp">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/plugin_surface_variant" />
+        </shape>
+    </item>
+</layer-list>

--- a/ai-assistant/src/main/res/drawable/ic_attach_file.xml
+++ b/ai-assistant/src/main/res/drawable/ic_attach_file.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M16.5,6v11.5c0,2.21 -1.79,4 -4,4s-4,-1.79 -4,-4V5c0,-1.38 1.12,-2.5 2.5,-2.5s2.5,1.12 2.5,2.5v10.5c0,0.55 -0.45,1 -1,1s-1,-0.45 -1,-1V6H10v9.5c0,1.38 1.12,2.5 2.5,2.5s2.5,-1.12 2.5,-2.5V5c0,-2.21 -1.79,-4 -4,-4S7,2.79 7,5v12.5c0,3.04 2.46,5.5 5.5,5.5s5.5,-2.46 5.5,-5.5V6H16.5z"/>
+</vector>

--- a/ai-assistant/src/main/res/drawable/ic_expand_less.xml
+++ b/ai-assistant/src/main/res/drawable/ic_expand_less.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,8l-6,6 1.41,1.41L12,10.83l4.59,4.58L18,14z"/>
+</vector>

--- a/ai-assistant/src/main/res/drawable/ic_expand_more.xml
+++ b/ai-assistant/src/main/res/drawable/ic_expand_more.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M16.59,8.59L12,13.17 7.41,8.59 6,10l6,6 6,-6z"/>
+</vector>

--- a/ai-assistant/src/main/res/drawable/ic_more_vert.xml
+++ b/ai-assistant/src/main/res/drawable/ic_more_vert.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+</vector>

--- a/ai-assistant/src/main/res/drawable/ic_send.xml
+++ b/ai-assistant/src/main/res/drawable/ic_send.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M2.01,21L23,12 2.01,3 2,10l15,2 -15,2z"/>
+</vector>

--- a/ai-assistant/src/main/res/drawable/ic_stop.xml
+++ b/ai-assistant/src/main/res/drawable/ic_stop.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M8,6h8c1.1,0 2,0.9 2,2v8c0,1.1 -0.9,2 -2,2H8c-1.1,0 -2,-0.9 -2,-2V8C6,6.9 6.9,6 8,6z"/>
+</vector>

--- a/ai-assistant/src/main/res/layout/fragment_chat.xml
+++ b/ai-assistant/src/main/res/layout/fragment_chat.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Every fixed-height element here is a direct tax on chat_recycler_view: LinearLayout gives a
+  weighted child only the leftover space, so once the chrome exceeds the container the history is
+  measured at zero and stops scrolling (ADFA-3070, seen in the bottom sheet in landscape). Keep the
+  chrome bounded — a minHeight on the list would not help, weighted children are measured EXACTLY.
+-->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -9,7 +15,7 @@
     <LinearLayout
         android:id="@+id/chat_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="@dimen/chat_toolbar_height"
         android:background="@color/plugin_surface_variant"
         android:gravity="center_vertical"
         android:orientation="horizontal"
@@ -20,31 +26,55 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="AI Agent"
+            android:text="@string/ai_agent"
             android:textColor="@color/plugin_on_surface"
-            android:textSize="20sp"
+            android:textSize="@dimen/chat_title_text_size"
             android:textStyle="bold" />
 
-        <Button
+        <ImageButton
             android:id="@+id/btn_overflow_menu"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:text="⋮"
-            android:textSize="24sp"
-            android:textColor="@color/plugin_on_surface"
-            android:background="?android:attr/selectableItemBackground"
-            android:padding="0dp" />
+            android:layout_width="@dimen/chat_composer_button_size"
+            android:layout_height="@dimen/chat_composer_button_size"
+            android:background="?android:attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/desc_overflow_menu"
+            android:padding="@dimen/chat_composer_icon_padding"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_more_vert"
+            android:tint="@color/plugin_on_surface" />
     </LinearLayout>
 
-    <!-- RecyclerView for messages -->
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/chat_recycler_view"
+    <!-- The toggle floats over the list rather than taking a row of its own, so hiding the
+         composer hands its full height to the history instead of trading most of it back. -->
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        android:background="@color/plugin_surface" />
+        android:layout_weight="1">
 
-    <!-- Hidden views that code expects -->
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/chat_recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/plugin_surface" />
+
+        <!-- Taller than it looks: the drawn tab is the bottom 16dp, the rest is a transparent
+             finger target. Costs the list no height — it overlays, it is not a row. -->
+        <ImageButton
+            android:id="@+id/btn_show_composer"
+            android:layout_width="@dimen/chat_composer_toggle_width"
+            android:layout_height="@dimen/chat_composer_toggle_touch_height"
+            android:layout_gravity="bottom|center_horizontal"
+            android:background="@drawable/bg_composer_tab_up"
+            android:contentDescription="@string/desc_show_composer"
+            android:paddingStart="@dimen/chat_composer_tab_padding_horizontal"
+            android:paddingEnd="@dimen/chat_composer_tab_padding_horizontal"
+            android:paddingTop="@dimen/chat_composer_tab_padding_top"
+            android:paddingBottom="@dimen/chat_composer_tab_padding_vertical"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_expand_less"
+            android:tint="@color/plugin_on_surface_variant"
+            android:visibility="gone" />
+    </FrameLayout>
+
     <TextView
         android:id="@+id/empty_chat_view"
         android:layout_width="wrap_content"
@@ -72,60 +102,105 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:background="@color/plugin_surface_variant"
-        android:elevation="8dp"
-        android:padding="12dp">
+        android:background="@drawable/bg_input_bar"
+        android:clipToPadding="false"
+        android:padding="@dimen/chat_input_bar_padding">
 
-        <LinearLayout
+        <!-- Hangs off the group's top border, below it, so it never reaches into the chat text.
+             Its height doubles as the group's top padding. -->
+        <ImageButton
+            android:id="@+id/btn_hide_composer"
+            android:layout_width="@dimen/chat_composer_toggle_width"
+            android:layout_height="@dimen/chat_composer_toggle_height"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/chat_input_bar_padding_negative"
+            android:layout_marginBottom="@dimen/chat_composer_tab_spacing"
+            android:background="@drawable/bg_composer_tab_down"
+            android:contentDescription="@string/desc_hide_composer"
+            android:paddingStart="@dimen/chat_composer_tab_padding_horizontal"
+            android:paddingEnd="@dimen/chat_composer_tab_padding_horizontal"
+            android:paddingTop="@dimen/chat_composer_tab_padding_vertical"
+            android:paddingBottom="@dimen/chat_composer_tab_padding_vertical"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_expand_more"
+            android:tint="@color/plugin_on_surface_variant"
+            android:visibility="gone" />
+
+        <!-- Costs a row only while context files are attached; ChatFragment toggles it. -->
+        <HorizontalScrollView
+            android:id="@+id/context_chip_scroll"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/btn_add_context"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="\@" />
+            android:scrollbars="none"
+            android:visibility="gone">
 
             <LinearLayout
                 android:id="@+id/context_chip_group"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:orientation="horizontal" />
-        </LinearLayout>
-
-        <EditText
-            android:id="@+id/prompt_input_edittext"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Type a message..."
-            android:minHeight="56dp" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/backend_status_text"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Gemini" />
-
-            <Button
-                android:id="@+id/send_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:enabled="false"
-                android:text="Send" />
-        </LinearLayout>
-    </LinearLayout>
+                android:orientation="horizontal" />
+        </HorizontalScrollView>
 
-    <View
-        android:id="@+id/keyboard_spacer"
-        android:layout_width="match_parent"
-        android:layout_height="0dp" />
+        <!-- Attach, input and send share one bordered field so they read as a single control,
+             with both icons centred against the input however tall it has grown. -->
+        <LinearLayout
+            android:id="@+id/composer_box"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_chat_composer"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="2dp"
+            android:paddingEnd="2dp">
+
+            <ImageButton
+                android:id="@+id/btn_add_context"
+                android:layout_width="@dimen/chat_composer_button_size"
+                android:layout_height="@dimen/chat_composer_button_size"
+                android:background="?android:attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/desc_attach_context_file"
+                android:padding="@dimen/chat_composer_icon_padding"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_attach_file"
+                android:tint="@color/plugin_on_surface_variant" />
+
+            <EditText
+                android:id="@+id/prompt_input_edittext"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:background="@null"
+                android:gravity="center_vertical|start"
+                android:hint="@string/hint_enter_message"
+                android:inputType="textMultiLine|textCapSentences"
+                android:maxLines="@integer/chat_input_max_lines"
+                android:minHeight="@dimen/chat_input_min_height"
+                android:paddingTop="10dp"
+                android:paddingBottom="10dp"
+                android:scrollbars="vertical"
+                android:textColor="@color/plugin_on_surface"
+                android:textColorHint="@color/plugin_text_muted" />
+
+            <ImageButton
+                android:id="@+id/send_button"
+                android:layout_width="@dimen/chat_composer_button_size"
+                android:layout_height="@dimen/chat_composer_button_size"
+                android:background="?android:attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/desc_send_message"
+                android:padding="@dimen/chat_composer_icon_padding"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_send"
+                android:tint="@color/chat_send_tint" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/backend_status_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/chat_caption_spacing"
+            android:textColor="@color/plugin_text_muted"
+            android:textSize="@dimen/chat_caption_text_size" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/ai-assistant/src/main/res/values/dimens.xml
+++ b/ai-assistant/src/main/res/values/dimens.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  One set of metrics for every orientation, deliberately.
+
+  EditorActivity declares configChanges="orientation|screenSize|...", so rotating never recreates
+  the activity, the fragment or these views. Alternative-resource buckets (values-h480dp and the
+  like) are therefore resolved once at inflation and frozen: after a rotation the layout keeps
+  whichever orientation's values it was born with, silently and with no way to notice from the
+  build. So the sizes below are a compromise that has to work on a phone in landscape (the
+  tightest case) while still looking right in portrait. Anything that genuinely must change with
+  orientation belongs in ChatFragment.onConfigurationChanged, not here.
+-->
+<resources>
+    <dimen name="chat_toolbar_height">48dp</dimen>
+    <dimen name="chat_title_text_size">18sp</dimen>
+    <dimen name="chat_input_bar_padding">8dp</dimen>
+    <!--
+      Cancels the group's 8dp top padding bar the 1dp border itself, so the tab hangs immediately
+      under the border without covering it. Keep in step with chat_input_bar_padding.
+    -->
+    <dimen name="chat_input_bar_padding_negative">-7dp</dimen>
+    <dimen name="chat_input_min_height">48dp</dimen>
+    <dimen name="chat_composer_button_size">44dp</dimen>
+    <dimen name="chat_composer_icon_padding">10dp</dimen>
+    <dimen name="chat_composer_corner_radius">22dp</dimen>
+    <dimen name="chat_caption_text_size">12sp</dimen>
+    <dimen name="chat_caption_spacing">4dp</dimen>
+    <integer name="chat_input_max_lines">4</integer>
+
+    <!-- Composer tab. The collapsed one overlays the list, so it costs no layout height. -->
+    <dimen name="chat_composer_toggle_width">48dp</dimen>
+    <dimen name="chat_composer_toggle_height">16dp</dimen>
+    <dimen name="chat_composer_tab_padding_horizontal">10dp</dimen>
+    <dimen name="chat_composer_tab_padding_vertical">2dp</dimen>
+    <!-- Keeps the expanded tab off the input field below it. -->
+    <dimen name="chat_composer_tab_spacing">6dp</dimen>
+    <dimen name="chat_composer_toggle_touch_height">48dp</dimen>
+    <dimen name="chat_composer_tab_inset_top">32dp</dimen>
+    <dimen name="chat_composer_tab_padding_top">34dp</dimen>
+</resources>

--- a/ai-assistant/src/main/res/values/integers.xml
+++ b/ai-assistant/src/main/res/values/integers.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Composer auto-hide tuning. Integers rather than dimens: both are compared against values that
+  are already in their own unit — Configuration.screenHeightDp is dp, and the delay is
+  milliseconds — whereas getDimension() resolves to px and would silently scale with density.
+-->
+<resources>
+    <!-- Below this available height the composer costs more than the history can spare. -->
+    <integer name="chat_composer_compact_height_dp">480</integer>
+    <!-- Idle time before the composer folds away on a short screen. -->
+    <integer name="chat_composer_auto_hide_ms">5000</integer>
+</resources>

--- a/ai-assistant/src/main/res/values/strings.xml
+++ b/ai-assistant/src/main/res/values/strings.xml
@@ -7,8 +7,13 @@
     <string name="chat_title">AI Chat</string>
     <string name="hint_enter_message">Enter your message…</string>
     <string name="btn_send">Send</string>
-    <string name="btn_stop">Stop</string>
     <string name="btn_clear_chat">Clear chat</string>
+    <string name="desc_attach_context_file">Attach a file as context</string>
+    <string name="desc_send_message">Send message</string>
+    <string name="desc_stop_agent">Stop the agent</string>
+    <string name="desc_show_composer">Show the message box</string>
+    <string name="desc_hide_composer">Hide the message box</string>
+    <string name="desc_overflow_menu">More options</string>
 
     <!-- Menu Items -->
     <string name="menu_clear_chat">Clear chat</string>
@@ -154,7 +159,6 @@
     <string name="type_a_message_or_prompt">Type a message or prompt…</string>
     <string name="experimental_ai_use_at_your_own_risk">⚠️ Experimental AI. Use at your own risk.</string>
     <string name="current_ai_backend">Current AI backend</string>
-    <string name="send">Send</string>
 
     <!-- File picker -->
     <string name="file_picker_title">Select Files</string>


### PR DESCRIPTION
## Description

Fixed an issue where the agent chat is not scrollable on shorter screens, such as in landscape orientation. The previous `LinearLayout` setup caused the `RecyclerView` to be measured at zero height once the UI chrome exceeded the container's height. The layout has been updated to bound the chrome elements and float the composer toggle over the list. Additionally, an auto-hide controller was introduced to fold the composer away on compact screens, ensuring maximum space for the chat history.

## Details

* Extracted the composer behavior into a dedicated `ComposerAutoHideController` to manage visibility state and auto-hide countdowns.
* Added integer resources to define compact screens (under 480dp) and trigger auto-hiding after 5 seconds of idle time.
* Implemented window inset handling to properly pad the `RecyclerView` around display cutouts in landscape orientation.
* Consolidated the attachment, input, and send controls into a single bordered composer box layout.


https://github.com/user-attachments/assets/2542ce74-6624-4591-bbd4-f8741b041427


## Ticket

[ADFA-3070](https://appdevforall.atlassian.net/browse/ADFA-3070)

## Observation

The auto-hide functionality includes explicit safeguards to ensure the composer remains visible if the user is typing, the input is not empty, the agent is actively running, or if touch exploration accessibility services are enabled.

[ADFA-3070]: https://appdevforall.atlassian.net/browse/ADFA-3070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ