### PR TITLE
ADFA-4500 | Show snippet dialogs and toasts through PluginWindows

### DIFF
--- a/snippets/src/main/AndroidManifest.xml
+++ b/snippets/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
 
         <meta-data
             android:name="plugin.min_ide_version"
-            android:value="1.0.0" />
+            android:value="26.36" />
 
         <meta-data
             android:name="plugin.permissions"

--- a/snippets/src/main/kotlin/com/codeonthego/snippets/ui/SnippetManagerFragment.kt
+++ b/snippets/src/main/kotlin/com/codeonthego/snippets/ui/SnippetManagerFragment.kt
@@ -144,9 +144,13 @@ class SnippetManagerFragment : Fragment() {
         }
 
         val editDialog = MaterialAlertDialogBuilder(ctx)
-            .setTitle(if (existing != null) "Edit Snippet" else "New Snippet")
+            .setTitle(
+                ctx.getString(
+                    if (existing != null) R.string.snippet_editor_title_edit else R.string.snippet_editor_title_new
+                )
+            )
             .setView(dialogView)
-            .setPositiveButton("Save") { _, _ ->
+            .setPositiveButton(ctx.getString(R.string.snippet_action_save)) { _, _ ->
                 val prefix = prefixInput.text?.toString()?.trim() ?: ""
                 val desc = descInput.text?.toString()?.trim() ?: ""
                 val lang = langSpinner.selectedItem?.toString() ?: ""
@@ -154,7 +158,7 @@ class SnippetManagerFragment : Fragment() {
                 val body = bodyInput.text?.toString()?.split("\n") ?: emptyList()
 
                 if (prefix.isEmpty() || desc.isEmpty() || lang.isEmpty() || scope.isEmpty()) {
-                    PluginWindows.showToast(ctx, "All fields are required")
+                    PluginWindows.showToast(ctx, ctx.getString(R.string.snippet_msg_all_fields_required))
                     return@setPositiveButton
                 }
 
@@ -175,7 +179,7 @@ class SnippetManagerFragment : Fragment() {
                 save()
                 renderList()
             }
-            .setNegativeButton("Cancel", null)
+            .setNegativeButton(ctx.getString(R.string.snippet_action_cancel), null)
             .create()
         PluginWindows.showDialog(editDialog)
         applyDialogButtonColors(editDialog)
@@ -186,14 +190,14 @@ class SnippetManagerFragment : Fragment() {
         val entry = snippets.getOrNull(index) ?: return
 
         val deleteDialog = MaterialAlertDialogBuilder(ctx)
-            .setTitle("Delete Snippet")
-            .setMessage("Delete \"${entry.prefix}\"?")
-            .setPositiveButton("Delete") { _, _ ->
+            .setTitle(ctx.getString(R.string.snippet_delete_title))
+            .setMessage(ctx.getString(R.string.snippet_delete_confirm, entry.prefix))
+            .setPositiveButton(ctx.getString(R.string.snippet_action_delete)) { _, _ ->
                 snippets.removeAt(index)
                 save()
                 renderList()
             }
-            .setNegativeButton("Cancel", null)
+            .setNegativeButton(ctx.getString(R.string.snippet_action_cancel), null)
             .create()
         PluginWindows.showDialog(deleteDialog)
         applyDialogButtonColors(deleteDialog)
@@ -213,10 +217,10 @@ class SnippetManagerFragment : Fragment() {
             SnippetsConfigParser.write(file, SnippetsConfig(snippets.toList()))
             SnippetsPlugin.instance?.invalidateCache()
             SnippetsPlugin.instance?.refreshRegistry()
-            PluginWindows.showToast(requireContext(), "Snippets saved")
+            PluginWindows.showToast(requireContext(), getString(R.string.snippet_msg_saved))
         } catch (e: Exception) {
             Log.e("SnippetManager", "Failed to save snippets", e)
-            PluginWindows.showToast(requireContext(), "Failed to save")
+            PluginWindows.showToast(requireContext(), getString(R.string.snippet_msg_save_failed))
         }
     }
 

--- a/snippets/src/main/kotlin/com/codeonthego/snippets/ui/SnippetManagerFragment.kt
+++ b/snippets/src/main/kotlin/com/codeonthego/snippets/ui/SnippetManagerFragment.kt
@@ -13,7 +13,6 @@ import android.widget.LinearLayout
 import android.widget.ArrayAdapter
 import android.widget.Spinner
 import android.widget.TextView
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.codeonthego.snippets.R
 import com.codeonthego.snippets.SnippetEntry
@@ -23,6 +22,7 @@ import com.codeonthego.snippets.SnippetsPlugin
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
+import com.itsaky.androidide.plugins.base.PluginWindows
 import com.itsaky.androidide.plugins.base.PluginFragmentHelper
 
 class SnippetManagerFragment : Fragment() {
@@ -154,7 +154,7 @@ class SnippetManagerFragment : Fragment() {
                 val body = bodyInput.text?.toString()?.split("\n") ?: emptyList()
 
                 if (prefix.isEmpty() || desc.isEmpty() || lang.isEmpty() || scope.isEmpty()) {
-                    Toast.makeText(ctx, "All fields are required", Toast.LENGTH_SHORT).show()
+                    PluginWindows.showToast(ctx, "All fields are required")
                     return@setPositiveButton
                 }
 
@@ -176,7 +176,8 @@ class SnippetManagerFragment : Fragment() {
                 renderList()
             }
             .setNegativeButton("Cancel", null)
-            .show()
+            .create()
+        PluginWindows.showDialog(editDialog)
         applyDialogButtonColors(editDialog)
     }
 
@@ -193,7 +194,8 @@ class SnippetManagerFragment : Fragment() {
                 renderList()
             }
             .setNegativeButton("Cancel", null)
-            .show()
+            .create()
+        PluginWindows.showDialog(deleteDialog)
         applyDialogButtonColors(deleteDialog)
     }
 
@@ -211,10 +213,10 @@ class SnippetManagerFragment : Fragment() {
             SnippetsConfigParser.write(file, SnippetsConfig(snippets.toList()))
             SnippetsPlugin.instance?.invalidateCache()
             SnippetsPlugin.instance?.refreshRegistry()
-            Toast.makeText(requireContext(), "Snippets saved", Toast.LENGTH_SHORT).show()
+            PluginWindows.showToast(requireContext(), "Snippets saved")
         } catch (e: Exception) {
             Log.e("SnippetManager", "Failed to save snippets", e)
-            Toast.makeText(requireContext(), "Failed to save", Toast.LENGTH_SHORT).show()
+            PluginWindows.showToast(requireContext(), "Failed to save")
         }
     }
 

--- a/snippets/src/main/res/values/strings.xml
+++ b/snippets/src/main/res/values/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="snippet_editor_title_new">New Snippet</string>
+	<string name="snippet_editor_title_edit">Edit Snippet</string>
+	<string name="snippet_action_save">Save</string>
+	<string name="snippet_action_cancel">Cancel</string>
+	<string name="snippet_action_delete">Delete</string>
+	<string name="snippet_delete_title">Delete Snippet</string>
+	<string name="snippet_delete_confirm">Delete \"%1$s\"?</string>
+	<string name="snippet_msg_all_fields_required">All fields are required</string>
+	<string name="snippet_msg_saved">Snippets saved</string>
+	<string name="snippet_msg_save_failed">Failed to save</string>
+</resources>


### PR DESCRIPTION
Plugin half of ADFA-4500. Host PR: appdevforall/CodeOnTheGo#1771.

## Blocked until the host lands

This does not compile against the current `libs/plugin-api.jar`, which has no `PluginWindows`. It needs CodeOnTheGo#1771 merged and a `chore: update libs` refresh first. Draft until then.

## What was wrong

Undocking Snippets into a floating window and tapping Add crashed the app. After that was fixed host-side, saving a filled-in snippet crashed it again, *after* the file had already been written, so the snippet persisted and the process died.

An undocked fragment runs against a window context created for `TYPE_APPLICATION_OVERLAY`, and the platform requires every window added through it to carry that same type. `MaterialAlertDialogBuilder(ctx).show()` builds a `TYPE_APPLICATION` window and `Toast.makeText` a `TYPE_TOAST` one, so both threw `IllegalArgumentException` while floating:

```
Window type mismatch. Window Context's window type is 2038,
while LayoutParams' type is set to 2005
  at android.widget.ToastPresenter.addToastView
```

Docked, `ctx` is the activity, so the same code worked. That is why this only ever reproduced undocked.

## Change

Both dialogs and all three toasts go through `PluginWindows`. Dialogs are built with `create()` and shown via `showDialog`; toasts use `showToast`, which posts against the application context. Both are no-ops while docked, so one call site is correct in either state.

`min_ide_version` moves from `1.0.0` to `26.36`, the release that ships `PluginWindows`.

## Sites changed

| Site | Was |
|---|---|
| `showEditor` | `MaterialAlertDialogBuilder(ctx).show()` |
| `confirmDelete` | `MaterialAlertDialogBuilder(ctx).show()` |
| `showEditor` validation | `Toast.makeText(ctx, ...)` |
| `save` success | `Toast.makeText(requireContext(), ...)` |
| `save` failure | `Toast.makeText(requireContext(), ...)` |

No remaining `Toast.makeText` or `android.widget.Toast` import in the file.

## Verification

Device (arm64 emulator, API 36), against a host build of CodeOnTheGo#1771:

- Undock, tap Add: dialog opens above the floating window, no crash.
- Fill and Save: snippet count 5 to 6, process PID unchanged, zero `Window type mismatch`, zero fatals.
- Save with empty fields: validation toast fires, no crash, count unchanged.
- Checked at font scale 1.0 and 2.0: no clipping, list scrolls.
