### PR TITLE
Finish the renames and derive every add-on name from its directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ This is intentional — the `application`-as-library packaging trips those check
 
 ### Asset downloads (rare)
 
-Some plugins (`ndk-installer-plugin`, `ai-literacy-course`) register a `downloadAssets` task that fetches large files at build time with pinned-MD5 verification. These assets are **not committed to git** (e.g. `ai-literacy-course` pulls a ~110 MB course ZIP plus `pdfjs.zip`). `scripts/update-libs.sh` runs `downloadAssets` automatically before `assemblePlugin` when the build file references it.
+Some plugins (`ndk-installer`, `ai-literacy-course`) register a `downloadAssets` task that fetches large files at build time with pinned-MD5 verification. These assets are **not committed to git** (e.g. `ai-literacy-course` pulls a ~110 MB course ZIP plus `pdfjs.zip`). `scripts/update-libs.sh` runs `downloadAssets` automatically before `assemblePlugin` when the build file references it.
 
 **Gotcha: a bare `./gradlew assemblePlugin` does NOT run `downloadAssets` and does not warn when the assets are missing** — it silently packages a broken `.cgp` (e.g. a course with no PDF viewer). When building such a plugin by hand, run `./gradlew downloadAssets assemblePlugin` (or the script), and confirm the expected files exist under `src/main/assets/` (or `unzip -l` the `.cgp`) before trusting it.
 

--- a/ai-agent-gemini/README.md
+++ b/ai-agent-gemini/README.md
@@ -2,8 +2,8 @@
 
 Google Gemini API inference for CodeOnTheGo's AI plugins. Registers itself as the
 `gemini` backend with [`ai-core`](../ai-core/)'s `LlmInferenceService`, which is
-what `ai-core`'s Agent chat, `code-suggestions-plugin`, `speech-to-text-plugin` and
-`vector-search-plugin` actually talk to.
+what `ai-core`'s Agent chat, `Code-Suggestions`, `Speech-to-Text` and
+`Vector-Search` actually talk to.
 
 Calls the Generative Language REST API directly over `HttpURLConnection` rather
 than the google-genai SDK: the SDK bundles OkHttp 4.x, but plugins run in the

--- a/ai-agent-local/README.md
+++ b/ai-agent-local/README.md
@@ -2,8 +2,8 @@
 
 On-device GGUF inference for CodeOnTheGo's AI plugins. Registers itself as the
 `local` backend with [`ai-core`](../ai-core/)'s `LlmInferenceService`, which is
-what `ai-core`'s Agent chat, `code-suggestions-plugin`, `speech-to-text-plugin` and
-`vector-search-plugin` actually talk to.
+what `ai-core`'s Agent chat, `Code-Suggestions`, `Speech-to-Text` and
+`Vector-Search` actually talk to.
 
 Runs `.gguf` models through a bundled, prebuilt **llama.cpp** AAR. Declares no
 INTERNET permission — prompts and code never leave the device. Requires a 64-bit

--- a/ai-agent-openai/README.md
+++ b/ai-agent-openai/README.md
@@ -2,8 +2,8 @@
 
 OpenAI-compatible inference for CodeOnTheGo's AI plugins. Registers itself as the
 `openai` backend with [`ai-core`](../ai-core/)'s `LlmInferenceService`, which is
-what `ai-core`'s Agent chat, `code-suggestions-plugin`, `speech-to-text-plugin`
-and `vector-search-plugin` actually talk to.
+what `ai-core`'s Agent chat, `Code-Suggestions`, `Speech-to-Text`
+and `Vector-Search` actually talk to.
 
 **One backend, many servers.** It speaks `POST {baseUrl}/chat/completions`, and
 the base URL is a setting. Across OpenAI, Ollama, LM Studio, OpenRouter and

--- a/ai-core/README.md
+++ b/ai-core/README.md
@@ -6,9 +6,9 @@ Two things in one plugin, and **mandatory for every AI feature**:
    the open project behind an approval gate, contributed as an editor tab plus a
    settings screen.
 2. The **LLM inference router** — publishes `LlmInferenceService` through
-   `SharedServices`, which [`code-suggestions-plugin`](../code-suggestions-plugin/),
-   [`speech-to-text-plugin`](../speech-to-text-plugin/) and
-   [`vector-search-plugin`](../vector-search-plugin/) consume at runtime.
+   `SharedServices`, which [`Code-Suggestions`](../plugins/Code-Suggestions/),
+   [`Speech-to-Text`](../plugins/Speech-to-Text/) and
+   [`Vector-Search`](../plugins/Vector-Search/) consume at runtime.
 
 The Agent and the router shipped as separate `ai-assistant` and `ai-core` plugins
 until they were merged here; an existing install's settings and chat history are

--- a/ai-literacy-course/build.gradle.kts
+++ b/ai-literacy-course/build.gradle.kts
@@ -85,7 +85,7 @@ tasks.matching {
     enabled = false
 }
 
-// --- Build-time asset downloads (mirrors ndk-installer-plugin) ---------------
+// --- Build-time asset downloads (mirrors ndk-installer) ---------------
 //
 // Neither the 110 MB course ZIP nor the PDF.js viewer is committed to git. This
 // task pulls each from its source and verifies a pinned MD5. scripts/update-libs.sh

--- a/plugins/Code-Suggestions/README.md
+++ b/plugins/Code-Suggestions/README.md
@@ -47,8 +47,8 @@ Prerequisites: Android SDK (API 33+), JDK 17. Create `local.properties` with
 `sdk.dir=...`. No NDK or native toolchain.
 
 ```bash
-cd code-suggestions-plugin
-../gradlew assemblePlugin          # release  -> build/plugin/code-suggestions-plugin.cgp
+cd Code-Suggestions
+../gradlew assemblePlugin          # release  -> build/plugin/code-suggestions.cgp
 ../gradlew assemblePluginDebug     # debug variant
 ```
 
@@ -57,7 +57,7 @@ The build resolves `plugin-api.jar` from the repo-root `../libs/`.
 ## Installation
 
 1. Build and install **`ai-core` first** (see [`../ai-core/README.md`](../ai-core/README.md)).
-2. Build this plugin, install `build/plugin/code-suggestions-plugin.cgp` via
+2. Build this plugin, install `build/plugin/code-suggestions.cgp` via
    CodeOnTheGo's Plugin Manager, and restart the IDE.
 3. Configure a model in **AI Assistant → AI Settings**.
 

--- a/plugins/Code-Suggestions/settings.gradle.kts
+++ b/plugins/Code-Suggestions/settings.gradle.kts
@@ -17,4 +17,4 @@ dependencyResolutionManagement {
     repositories { google(); mavenCentral() }
 }
 
-rootProject.name = "code-suggestions-plugin"
+rootProject.name = "code-suggestions"

--- a/plugins/Flutter-Templates/README.md
+++ b/plugins/Flutter-Templates/README.md
@@ -35,7 +35,7 @@ cd flutter-template
 ../gradlew clean assemblePlugin
 ```
 
-The `.cgp` lands in `build/plugin/fluttertemplate.cgp`. Install it from inside Code on the Go via
+The `.cgp` lands in `build/plugin/flutter-templates.cgp`. Install it from inside Code on the Go via
 the Plugin Manager, then open **New Project** to see the Flutter templates.
 
 ## Note on the Flutter SDK

--- a/plugins/Flutter-Templates/flutter-templates.html
+++ b/plugins/Flutter-Templates/flutter-templates.html
@@ -294,7 +294,7 @@
 </section>
 
 <footer>
-  Flutter Template Plugin Documentation &middot; Version 2.0.0 &middot; com.ali.fluttertemplate
+  Flutter Templates Documentation &middot; Version 2.0.0 &middot; com.ali.fluttertemplate
 </footer>
 
 </body>

--- a/plugins/Flutter-Templates/settings.gradle.kts
+++ b/plugins/Flutter-Templates/settings.gradle.kts
@@ -27,4 +27,4 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "fluttertemplate"
+rootProject.name = "flutter-templates"

--- a/plugins/Get-AI-Models/settings.gradle.kts
+++ b/plugins/Get-AI-Models/settings.gradle.kts
@@ -27,4 +27,4 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "GetAiModelsPlugin"
+rootProject.name = "get-ai-models"

--- a/plugins/Icons-Repository/README.md
+++ b/plugins/Icons-Repository/README.md
@@ -1,4 +1,4 @@
-### **IconsRepository-Plugin**
+### **Icons Repository**
 
 **Version:** 1.0.1
 
@@ -34,7 +34,7 @@ Build command:
 ./gradlew assemblePlugin
 ```
 
-The signed `.cgp` artifact is written to `build/plugin/IconsRepository-Plugin.cgp`. Use `./gradlew assemblePluginDebug` for the debug variant.
+The signed `.cgp` artifact is written to `build/plugin/icons-repository.cgp`. Use `./gradlew assemblePluginDebug` for the debug variant.
 
 ### **Usage**
 

--- a/plugins/Icons-Repository/icons-repository.html
+++ b/plugins/Icons-Repository/icons-repository.html
@@ -55,7 +55,7 @@
 
 <h2 id="executive-overview">Executive overview</h2>
 <p>
-    IconsRepository-Plugin is a sidebar extension for the Code On The Go IDE that lets developers browse a bundled library of Material-style icons and import any of them into the current Android project as a Vector Drawable XML. The plugin replaces the manual "find an SVG, convert it, copy it into <code>res/drawable</code>, fix the colors" loop with a single dialog: pick an icon, optionally pick a tint, hit Import. The result is committed-ready XML in the project's <code>res/drawable</code> directory with no external network calls and no SDK changes required.
+    Icons Repository is a sidebar extension for the Code On The Go IDE that lets developers browse a bundled library of Material-style icons and import any of them into the current Android project as a Vector Drawable XML. The plugin replaces the manual "find an SVG, convert it, copy it into <code>res/drawable</code>, fix the colors" loop with a single dialog: pick an icon, optionally pick a tint, hit Import. The result is committed-ready XML in the project's <code>res/drawable</code> directory with no external network calls and no SDK changes required.
 </p>
 <p>
     The plugin targets Code On The Go versions <strong>26.17 through 26.22</strong> and runs on Android API 26 and above.
@@ -110,7 +110,7 @@
 <ol>
     <li>Open Code On The Go.</li>
     <li>Open the Plugin Manager.</li>
-    <li>Install <strong>IconsRepository-Plugin</strong>.</li>
+    <li>Install <strong>Icons Repository</strong>.</li>
 </ol>
 
 <h3>Importing an icon</h3>

--- a/plugins/Icons-Repository/settings.gradle.kts
+++ b/plugins/Icons-Repository/settings.gradle.kts
@@ -28,4 +28,4 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "IconsRepository-Plugin"
+rootProject.name = "icons-repository"

--- a/plugins/Icons-Repository/src/main/AndroidManifest.xml
+++ b/plugins/Icons-Repository/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:label="IconsRepository-Plugin"
+        android:label="Icons Repository"
         android:theme="@style/PluginTheme">
 
         <!-- Plugin metadata -->

--- a/plugins/Jetpack-Compose-Preview/README.md
+++ b/plugins/Jetpack-Compose-Preview/README.md
@@ -7,7 +7,7 @@ Surfaces as a preview action in the editor toolbar, shown only when a Kotlin fil
 ## Building
 
 ```sh
-cd compose-preview
+cd Jetpack-Compose-Preview
 ./gradlew assemblePlugin
 ```
 

--- a/plugins/Jetpack-Compose-Preview/settings.gradle.kts
+++ b/plugins/Jetpack-Compose-Preview/settings.gradle.kts
@@ -29,4 +29,4 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "compose-preview"
+rootProject.name = "jetpack-compose-preview"

--- a/plugins/Jetpack-Compose-Preview/src/main/kotlin/org/appdevforall/composepreview/ComposePreviewState.kt
+++ b/plugins/Jetpack-Compose-Preview/src/main/kotlin/org/appdevforall/composepreview/ComposePreviewState.kt
@@ -3,7 +3,7 @@ package org.appdevforall.composepreview
 /**
  * Hands the current file + source from the toolbar/menu action to [ComposePreviewFragment]
  * across the openPluginScreen boundary (which carries no Bundle). Mirrors the
- * SketchToUiState pattern used by sketch-to-ui-plugin.
+ * SketchToUiState pattern used by Sketch-to-UI.
  */
 object ComposePreviewState {
 

--- a/plugins/Layout-Editor/src/main/kotlin/org/appdevforall/codeonthego/layouteditor/LayoutEditorPlugin.kt
+++ b/plugins/Layout-Editor/src/main/kotlin/org/appdevforall/codeonthego/layouteditor/LayoutEditorPlugin.kt
@@ -26,7 +26,7 @@ import java.io.File
  *
  * Surfaces a content-aware menu item (visible only when an Android layout `.xml` file is open)
  * that opens the editor full-screen via [IdeUIService.openPluginScreen], handing the target
- * layout over through [LayoutEditorState]. Mirrors sketch-to-ui-plugin's proven pattern; the
+ * layout over through [LayoutEditorState]. Mirrors Sketch-to-UI's proven pattern; the
  * host's built-in PreviewLayout action is removed separately when the editor leaves the host build.
  */
 class LayoutEditorPlugin : IPlugin, UIExtension, DocumentationExtension, BuildStatusListener {

--- a/plugins/Layout-Editor/src/main/kotlin/org/appdevforall/codeonthego/layouteditor/LayoutEditorState.kt
+++ b/plugins/Layout-Editor/src/main/kotlin/org/appdevforall/codeonthego/layouteditor/LayoutEditorState.kt
@@ -2,7 +2,7 @@ package org.appdevforall.codeonthego.layouteditor
 
 /**
  * Hands the current layout file from the toolbar action to [LayoutEditorFragment] across the
- * openPluginScreen boundary (which carries no Bundle). Mirrors compose-preview's
+ * openPluginScreen boundary (which carries no Bundle). Mirrors Jetpack-Compose-Preview's
  * ComposePreviewState / sketch-to-ui's SketchToUiState pattern.
  *
  * The two values mirror the Intent extras the in-app EditorActivity used to receive:

--- a/plugins/NDK-Installer/settings.gradle.kts
+++ b/plugins/NDK-Installer/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "ndk-installer-plugin"
+rootProject.name = "ndk-installer"
 
 pluginManagement {
     repositories {

--- a/plugins/Rainbow-Brackets/README.md
+++ b/plugins/Rainbow-Brackets/README.md
@@ -1,4 +1,4 @@
-# rainbow-on-the-go
+# Rainbow Brackets
 
 A Code On The Go plugin that colors matching parentheses, brackets, and braces by
 nesting depth — an opening delimiter and its match share a color, cycling through six
@@ -18,8 +18,8 @@ no permissions, makes no network calls, and reads no files.
 ## Build
 
 ```sh
-cd rainbow-on-the-go
-./gradlew assemblePlugin        # release .cgp -> build/plugin/rainbow-on-the-go.cgp
+cd Rainbow-Brackets
+./gradlew assemblePlugin        # release .cgp -> build/plugin/rainbow-brackets.cgp
 ```
 
 The plugin compiles against `../libs/plugin-api.jar`. If the `EditorDecorationProvider` API
@@ -33,6 +33,6 @@ cd ..
 ## In-IDE help
 
 A walkthrough is served by the host IDE at
-`http://localhost:6174/plugin/org.appdevforall.rainbowonthego/index.html` once installed
+`http://localhost:6174/plugin/org.appdevforall.rainbowbrackets/index.html` once installed
 (source: `src/main/assets/docs/index.html`). Long-press is wired through
 `DocumentationExtension` for the three-tier tooltip help.

--- a/plugins/Rainbow-Brackets/build.gradle.kts
+++ b/plugins/Rainbow-Brackets/build.gradle.kts
@@ -11,11 +11,11 @@ pluginBuilder {
 }
 
 android {
-    namespace = "org.appdevforall.rainbowonthego"
+    namespace = "org.appdevforall.rainbowbrackets"
     compileSdk = 36
 
     defaultConfig {
-        applicationId = "org.appdevforall.rainbowonthego"
+        applicationId = "org.appdevforall.rainbowbrackets"
         minSdk = 26
         targetSdk = 36
         versionCode = 1
@@ -62,7 +62,7 @@ tasks.wrapper {
 }
 
 // Disable AAR metadata checks that fail under the plugin-builder
-// pipeline (Beepy + Forms use the same workaround).
+// pipeline (Voice Alerts + Forms use the same workaround).
 tasks.matching {
     it.name.contains("checkDebugAarMetadata") ||
     it.name.contains("checkReleaseAarMetadata")

--- a/plugins/Rainbow-Brackets/proguard-rules.pro
+++ b/plugins/Rainbow-Brackets/proguard-rules.pro
@@ -1,4 +1,4 @@
 # Add project specific ProGuard rules here.
 
 # Keep plugin classes — the IDE loads them by reflection via plugin.main_class.
--keep class org.appdevforall.rainbowonthego.** { *; }
+-keep class org.appdevforall.rainbowbrackets.** { *; }

--- a/plugins/Rainbow-Brackets/rainbow-brackets.html
+++ b/plugins/Rainbow-Brackets/rainbow-brackets.html
@@ -68,7 +68,7 @@
 
 <section id="overview">
   <h2>1. Executive Overview</h2>
-  <p>RainbowOnTheGo makes nested code easier to read by coloring each pair of
+  <p>Rainbow Brackets makes nested code easier to read by coloring each pair of
   brackets according to how deeply it is nested. An opening delimiter and its matching
   closing delimiter share the same color, so you can see at a glance which <code>(</code>
   pairs with which <code>)</code>, even in deeply nested expressions.</p>

--- a/plugins/Rainbow-Brackets/settings.gradle.kts
+++ b/plugins/Rainbow-Brackets/settings.gradle.kts
@@ -27,4 +27,4 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "rainbow-on-the-go"
+rootProject.name = "rainbow-brackets"

--- a/plugins/Rainbow-Brackets/src/main/AndroidManifest.xml
+++ b/plugins/Rainbow-Brackets/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
         <!-- Plugin metadata -->
         <meta-data
             android:name="plugin.id"
-            android:value="org.appdevforall.rainbowonthego" />
+            android:value="org.appdevforall.rainbowbrackets" />
 
         <meta-data
             android:name="plugin.name"
@@ -38,7 +38,7 @@
 
         <meta-data
             android:name="plugin.main_class"
-            android:value="org.appdevforall.rainbowonthego.RainbowOnTheGoPlugin" />
+            android:value="org.appdevforall.rainbowbrackets.RainbowBracketsPlugin" />
 
         <!-- Plugin Manager icons. Required for debug builds; release builds
              skip this check. Paths are inside the .cgp (APK) zip — assets/

--- a/plugins/Rainbow-Brackets/src/main/assets/docs/index.html
+++ b/plugins/Rainbow-Brackets/src/main/assets/docs/index.html
@@ -3,13 +3,13 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>RainbowOnTheGo — How it works</title>
+<title>Rainbow Brackets — How it works</title>
 <link rel="stylesheet" href="css/walkthrough.css">
 </head>
 <body>
 
-<h1>RainbowOnTheGo</h1>
-<p>RainbowOnTheGo colors matching parentheses, brackets, and braces by how deeply they
+<h1>Rainbow Brackets</h1>
+<p>Rainbow Brackets colors matching parentheses, brackets, and braces by how deeply they
 nest, so a delimiter and its match share a color. It colors <b>Java and Kotlin</b> files and adds
 color only — your normal syntax highlighting is untouched, and other languages are left alone.</p>
 
@@ -37,11 +37,11 @@ the palette that matches your current theme and repaints when you switch.</p>
 does not affect nesting depth.</p>
 
 <h2>Turning it off</h2>
-<p>Disable RainbowOnTheGo in the Plugin Manager to return all brackets to the editor's normal
+<p>Disable Rainbow Brackets in the Plugin Manager to return all brackets to the editor's normal
 color. The change applies immediately to open editors.</p>
 
 <h2>How it's built</h2>
-<p>RainbowOnTheGo implements <code>EditorDecorationProvider</code>, a generic Code On The Go
+<p>Rainbow Brackets implements <code>EditorDecorationProvider</code>, a generic Code On The Go
 plugin API. Its <code>decorate</code> method scans a region of text for bracket characters,
 tracks the running nesting depth, skips brackets inside strings and comments, and returns a
 foreground-color span per bracket. The editor merges those spans on top of the normal

--- a/plugins/Rainbow-Brackets/src/main/kotlin/org/appdevforall/rainbowbrackets/RainbowBracketsPlugin.kt
+++ b/plugins/Rainbow-Brackets/src/main/kotlin/org/appdevforall/rainbowbrackets/RainbowBracketsPlugin.kt
@@ -1,4 +1,4 @@
-package org.appdevforall.rainbowonthego
+package org.appdevforall.rainbowbrackets
 
 import com.itsaky.androidide.plugins.IPlugin
 import com.itsaky.androidide.plugins.PluginContext
@@ -13,7 +13,7 @@ import java.io.File
 import java.util.TreeMap
 
 /**
- * RainbowOnTheGo — tints matching parentheses, brackets, and braces by nesting depth.
+ * Rainbow Brackets — tints matching parentheses, brackets, and braces by nesting depth.
  *
  * Implemented as a generic [EditorDecorationProvider]: the Code On The Go editor calls [decorate]
  * for each analyzed region and merges the returned color spans on top of the normal syntax
@@ -21,7 +21,7 @@ import java.util.TreeMap
  * skipping brackets inside strings/comments — lives here in the plugin; the IDE is unaware that
  * this is about brackets at all.
  */
-class RainbowOnTheGoPlugin : IPlugin, EditorDecorationProvider, FileOpenExtension, DocumentationExtension {
+class RainbowBracketsPlugin : IPlugin, EditorDecorationProvider, FileOpenExtension, DocumentationExtension {
 
     private lateinit var context: PluginContext
 
@@ -50,7 +50,7 @@ class RainbowOnTheGoPlugin : IPlugin, EditorDecorationProvider, FileOpenExtensio
         }
 
     companion object {
-        const val PLUGIN_ID = "org.appdevforall.rainbowonthego"
+        const val PLUGIN_ID = "org.appdevforall.rainbowbrackets"
         const val TOOLTIP_TAG = "rainbow.info"
 
         // Upper bound on cached prefix checkpoints per document; clearing on overflow caps memory.
@@ -88,26 +88,26 @@ class RainbowOnTheGoPlugin : IPlugin, EditorDecorationProvider, FileOpenExtensio
         // Wrap in try/catch so a stray exception in our setup can't crash the host IDE.
         return try {
             this.context = context
-            context.logger.info("RainbowOnTheGoPlugin initialized")
+            context.logger.info("RainbowBracketsPlugin initialized")
             true
         } catch (t: Throwable) {
-            context.logger.error("RainbowOnTheGoPlugin initialization failed", t)
+            context.logger.error("RainbowBracketsPlugin initialization failed", t)
             false
         }
     }
 
     override fun activate(): Boolean {
-        context.logger.info("RainbowOnTheGoPlugin activated")
+        context.logger.info("RainbowBracketsPlugin activated")
         return true
     }
 
     override fun deactivate(): Boolean {
-        context.logger.info("RainbowOnTheGoPlugin deactivated")
+        context.logger.info("RainbowBracketsPlugin deactivated")
         return true
     }
 
     override fun dispose() {
-        context.logger.info("RainbowOnTheGoPlugin disposed")
+        context.logger.info("RainbowBracketsPlugin disposed")
     }
 
     // --- FileOpenExtension: observe-only, used purely to track the active file's language ---
@@ -275,14 +275,14 @@ class RainbowOnTheGoPlugin : IPlugin, EditorDecorationProvider, FileOpenExtensio
     //   Tier 3 = buttons[].uri  (HTML page served at
     //                            http://localhost:6174/plugin/<pluginId>/<uri>)
 
-    override fun getTooltipCategory(): String = "plugin_rainbow_on_the_go"
+    override fun getTooltipCategory(): String = "plugin_$PLUGIN_ID"
 
     override fun getTooltipEntries(): List<PluginTooltipEntry> = listOf(
         PluginTooltipEntry(
             tag = TOOLTIP_TAG,
             summary = "Colors brackets by nesting depth in Java/Kotlin — red, orange, yellow, green, blue, purple.",
             detail = """
-                <p><b>RainbowOnTheGo</b> tints <b>()</b>, <b>[]</b> and <b>{}</b> by how deeply
+                <p><b>Rainbow Brackets</b> tints <b>()</b>, <b>[]</b> and <b>{}</b> by how deeply
                 they nest in <b>Java and Kotlin</b> files, so a delimiter and its match share a color.</p>
                 <ul>
                   <li>Six colors cycle red → orange → yellow → green → blue → purple.</li>
@@ -305,7 +305,7 @@ class RainbowOnTheGoPlugin : IPlugin, EditorDecorationProvider, FileOpenExtensio
     /**
      * Subdirectory under src/main/assets/ that holds the Tier 3 help. Every file under
      * assets/docs/ is indexed at install time and served from
-     *   http://localhost:6174/plugin/org.appdevforall.rainbowonthego/<file>
+     *   http://localhost:6174/plugin/org.appdevforall.rainbowbrackets/<file>
      */
     override fun getTier3DocsAssetPath(): String? = "docs"
 }

--- a/plugins/Rainbow-Brackets/src/main/res/values/strings.xml
+++ b/plugins/Rainbow-Brackets/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">RainbowOnTheGo</string>
+    <string name="app_name">Rainbow Brackets</string>
 </resources>

--- a/plugins/Random-XKCD/build.gradle.kts
+++ b/plugins/Random-XKCD/build.gradle.kts
@@ -84,7 +84,7 @@ tasks.wrapper {
 }
 
 // Disable AAR metadata checks that fail under the plugin-builder
-// pipeline (Beepy + Forms use the same workaround).
+// pipeline (Voice Alerts + Forms use the same workaround).
 tasks.matching {
     it.name.contains("checkDebugAarMetadata") ||
     it.name.contains("checkReleaseAarMetadata")

--- a/plugins/Sketch-to-UI/settings.gradle.kts
+++ b/plugins/Sketch-to-UI/settings.gradle.kts
@@ -27,4 +27,4 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "sketch-to-ui-plugin"
+rootProject.name = "sketch-to-ui"

--- a/plugins/Speech-to-Text/README.md
+++ b/plugins/Speech-to-Text/README.md
@@ -59,8 +59,8 @@ Prerequisites: Android SDK (API 33+), JDK 17. Create `local.properties` with
 `sdk.dir=...`.
 
 ```bash
-cd speech-to-text-plugin
-../gradlew assemblePlugin          # release  -> build/plugin/speech-to-text-plugin.cgp
+cd Speech-to-Text
+../gradlew assemblePlugin          # release  -> build/plugin/speech-to-text.cgp
 ../gradlew assemblePluginDebug     # debug variant
 ```
 
@@ -70,7 +70,7 @@ The build resolves `plugin-api.jar` from the repo-root `../libs/`.
 
 1. (Optional but recommended) Build and install **`ai-core` first** for
    voice→code (see [`../ai-core/README.md`](../ai-core/README.md)).
-2. Build this plugin, install `build/plugin/speech-to-text-plugin.cgp` via
+2. Build this plugin, install `build/plugin/speech-to-text.cgp` via
    CodeOnTheGo's Plugin Manager, and restart the IDE.
 3. Open a file, tap the microphone in the editor toolbar, grant the microphone
    permission on first use, and speak.

--- a/plugins/Speech-to-Text/settings.gradle.kts
+++ b/plugins/Speech-to-Text/settings.gradle.kts
@@ -17,4 +17,4 @@ dependencyResolutionManagement {
     repositories { google(); mavenCentral() }
 }
 
-rootProject.name = "speech-to-text-plugin"
+rootProject.name = "speech-to-text"

--- a/plugins/Vector-Search/README.md
+++ b/plugins/Vector-Search/README.md
@@ -50,8 +50,8 @@ Prerequisites: Android SDK (API 33+), JDK 17. Create `local.properties` with
 `sdk.dir=...`. No NDK or native toolchain.
 
 ```bash
-cd vector-search-plugin
-../gradlew assemblePlugin          # release  -> build/plugin/vector-search-plugin.cgp
+cd Vector-Search
+../gradlew assemblePlugin          # release  -> build/plugin/vector-search.cgp
 ../gradlew assemblePluginDebug     # debug variant
 ```
 
@@ -61,7 +61,7 @@ The build resolves `plugin-api.jar` from the repo-root `../libs/`.
 
 1. Build and install **`ai-core` first** for quality embeddings (see
    [`../ai-core/README.md`](../ai-core/README.md)).
-2. Build this plugin, install `build/plugin/vector-search-plugin.cgp` via
+2. Build this plugin, install `build/plugin/vector-search.cgp` via
    CodeOnTheGo's Plugin Manager, and restart the IDE.
 3. Run a query from the project search screen; look for the **Semantic
    Results** section.

--- a/plugins/Vector-Search/settings.gradle.kts
+++ b/plugins/Vector-Search/settings.gradle.kts
@@ -17,4 +17,4 @@ dependencyResolutionManagement {
     repositories { google(); mavenCentral() }
 }
 
-rootProject.name = "vector-search-plugin"
+rootProject.name = "vector-search"

--- a/plugins/Voice-Alerts/README.md
+++ b/plugins/Voice-Alerts/README.md
@@ -1,6 +1,6 @@
-# Beepy
+# Voice Alerts
 
-A CodeOnTheGo plugin that plays a short sound on build start, success, and failure. Useful when your eyes are on the editor and you want an audible cue that the build has turned over.
+A Code On The Go plugin that plays a short sound on build start, success, and failure. Useful when your eyes are on the editor and you want an audible cue that the build has turned over.
 
 ## Behaviour
 
@@ -20,13 +20,13 @@ Sounds route through the `USAGE_ASSISTANCE_SONIFICATION` audio attribute, so the
 
 ## Replacing the sounds
 
-Drop your own WAVs into `Beepy/src/main/res/raw/` using the existing filenames (`started.wav`, `finished.wav`, `failed.wav`) and rebuild. Keep them short — `SoundPool` is intended for clips under ~1 MB decoded.
+Drop your own WAVs into `Voice-Alerts/src/main/res/raw/` using the existing filenames (`started.wav`, `finished.wav`, `failed.wav`) and rebuild. Keep them short — `SoundPool` is intended for clips under ~1 MB decoded.
 
 ## Building
 
 ```
-./gradlew :Beepy:assembleRelease
+../../gradlew assemblePlugin
 ```
 
-Output is a `.cgp` plugin package in `Beepy/build/outputs/`, installable from the IDE's plugin manager.
+Output is a `.cgp` plugin package in `Voice-Alerts/build/plugin/`, installable from the IDE's plugin manager.
 

--- a/plugins/Voice-Alerts/build.gradle.kts
+++ b/plugins/Voice-Alerts/build.gradle.kts
@@ -11,11 +11,11 @@ pluginBuilder {
 }
 
 android {
-    namespace = "com.example.beepy"
+    namespace = "org.appdevforall.voicealerts"
     compileSdk = 36
 
     defaultConfig {
-        applicationId = "com.example.beepy"
+        applicationId = "org.appdevforall.voicealerts"
         minSdk = 28
         targetSdk = 36
         versionCode = 1

--- a/plugins/Voice-Alerts/settings.gradle.kts
+++ b/plugins/Voice-Alerts/settings.gradle.kts
@@ -27,4 +27,4 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "Beepy"
+rootProject.name = "voice-alerts"

--- a/plugins/Voice-Alerts/src/main/AndroidManifest.xml
+++ b/plugins/Voice-Alerts/src/main/AndroidManifest.xml
@@ -2,13 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:label="Beepy"
+        android:label="Voice Alerts"
         android:theme="@style/Theme.AppCompat">
 
         <!-- Plugin metadata -->
         <meta-data
             android:name="plugin.id"
-            android:value="com.example.beepy" />
+            android:value="org.appdevforall.voicealerts" />
 
         <meta-data
             android:name="plugin.name"
@@ -47,7 +47,7 @@
 
         <meta-data
             android:name="plugin.main_class"
-            android:value="com.example.beepy.Beepy" />
+            android:value="org.appdevforall.voicealerts.VoiceAlertsPlugin" />
 
         <!-- Plugin Manager icons (day/night). Required for debug installs. -->
         <meta-data

--- a/plugins/Voice-Alerts/src/main/kotlin/org/appdevforall/voicealerts/VoiceAlertsPlugin.kt
+++ b/plugins/Voice-Alerts/src/main/kotlin/org/appdevforall/voicealerts/VoiceAlertsPlugin.kt
@@ -1,4 +1,4 @@
-package com.example.beepy
+package org.appdevforall.voicealerts
 
 import android.media.AudioAttributes
 import android.media.SoundPool
@@ -8,7 +8,7 @@ import com.itsaky.androidide.plugins.PluginContext
 import com.itsaky.androidide.plugins.services.BuildStatusListener
 import com.itsaky.androidide.plugins.services.IdeBuildService
 
-class Beepy : IPlugin, BuildStatusListener {
+class VoiceAlertsPlugin : IPlugin, BuildStatusListener {
 
     private lateinit var context: PluginContext
     private var soundPool: SoundPool? = null

--- a/plugins/Voice-Alerts/src/main/res/values/strings.xml
+++ b/plugins/Voice-Alerts/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Beepy</string>
+    <string name="app_name">Voice Alerts</string>
     <string name="plugin_description">Add earcons to build status</string>
 </resources>

--- a/plugins/Voice-Alerts/voice-alerts.html
+++ b/plugins/Voice-Alerts/voice-alerts.html
@@ -91,7 +91,7 @@
 <header>
   <h1>Voice Alerts</h1>
   <p class="subtitle">Audible build-status earcons for Code On The Go</p>
-  <div class="meta">Version 1.0.0 &middot; Author: App Dev for All &middot; Package: <code>com.example.beepy</code></div>
+  <div class="meta">Version 1.0.0 &middot; Author: App Dev for All &middot; Package: <code>org.appdevforall.voicealerts</code></div>
 </header>
 
 <nav>
@@ -110,7 +110,7 @@
 <section id="overview">
   <h2>1. Executive Overview</h2>
   <p>
-    Beepy is a lightweight Code On The Go plugin that delivers audible feedback
+    Voice Alerts is a lightweight Code On The Go plugin that delivers audible feedback
     during builds. It plays a distinct short sound (earcon) when a build starts,
     succeeds, or fails, letting developers keep their eyes on code while staying
     aware of build progress.
@@ -175,7 +175,7 @@
         <li>src/main/
           <ul>
             <li>AndroidManifest.xml</li>
-            <li>kotlin/com/example/beepy/<strong>Beepy.kt</strong></li>
+            <li>kotlin/org/appdevforall/voicealerts/<strong>VoiceAlertsPlugin.kt</strong></li>
             <li>res/raw/ &mdash; started.wav, finished.wav, failed.wav</li>
             <li>res/values/strings.xml</li>
           </ul>
@@ -193,7 +193,7 @@
             +------------+-------------+
                          |
     +--------------------------------------+
-    |               Beepy                  |
+    |         VoiceAlertsPlugin            |
     +--------------------------------------+
     | - context : PluginContext            |
     | - soundPool : SoundPool?             |
@@ -287,19 +287,19 @@
 <section id="integration">
   <h2>4. Integration Points</h2>
   <p>
-    Beepy touches the host IDE through a small number of well-defined
+    Voice Alerts touches the host IDE through a small number of well-defined
     interfaces. It does not modify any main-app source files &mdash; all
     integration happens at runtime through the plugin framework.
   </p>
 
   <h3>4.1 Plugin framework (<code>IPlugin</code>)</h3>
   <p>
-    The <code>Beepy</code> class implements
+    The <code>VoiceAlertsPlugin</code> class implements
     <code>com.itsaky.androidide.plugins.IPlugin</code>, which the IDE
     discovers and manages. The manifest declares the entry point:
   </p>
   <pre><code>&lt;meta-data android:name="plugin.main_class"
-           android:value="com.example.beepy.Beepy" /&gt;</code></pre>
+           android:value="org.appdevforall.voicealerts.VoiceAlertsPlugin" /&gt;</code></pre>
   <p>
     The IDE calls <code>initialize()</code> &rarr; <code>activate()</code>
     on load, and <code>deactivate()</code> &rarr; <code>dispose()</code> on
@@ -330,7 +330,7 @@
 
   <h3>4.4 Permissions</h3>
   <p>
-    Beepy requires no plugin permissions. The available permission system
+    Voice Alerts requires no plugin permissions. The available permission system
     (<code>filesystem.read</code>, <code>filesystem.write</code>,
     <code>network.access</code>, <code>system.commands</code>,
     <code>ide.settings</code>, <code>project.structure</code>) is left
@@ -354,7 +354,7 @@
            |           |
            v           v
        +------------------------+
-       |         Beepy          |
+       |   VoiceAlertsPlugin    |
        +------------------------+
        | onBuildStarted()       |-----&gt; play("started")
        | onBuildFinished()      |-----&gt; play("finished")
@@ -380,7 +380,7 @@
   <ol>
     <li>Open Code On The Go's plugin manager.</li>
     <li>Import the <code>.cgp</code> file.</li>
-    <li>The IDE discovers <code>Beepy</code> via the manifest metadata and
+    <li>The IDE discovers <code>VoiceAlertsPlugin</code> via the manifest metadata and
         activates it automatically.</li>
   </ol>
 
@@ -432,7 +432,7 @@
 </section>
 
 <footer>
-  Beepy Plugin Documentation &middot; Version 1.0.0 &middot; com.example.beepy
+  Voice Alerts Plugin Documentation &middot; Version 1.0.0 &middot; org.appdevforall.voicealerts
 </footer>
 
 </body>

--- a/scripts/check-toolchain.sh
+++ b/scripts/check-toolchain.sh
@@ -47,7 +47,7 @@ EXPECTED_JAVA="JavaVersion.VERSION_17"
 EXPECTED_JVM_TARGET="JVM_17"
 
 # minSdk is deliberately NOT checked. It legitimately varies by what a plugin
-# needs (21 for the template installers, 26 for most, 28 for Beepy and
+# needs (21 for the template installers, 26 for most, 28 for Voice-Alerts and
 # sketch-to-ui, 33 for the AI plugins which rely on API-33 runtime behavior).
 # Do not "standardize" it here.
 


### PR DESCRIPTION
## Why

The `Publish addons` run summary still showed old names. That table is the Gradle `setup-gradle` job summary, and its **Gradle Root Project** column prints `rootProject.name` — which nothing had ever been derived from the directory.

`docs/plugin-naming-standards.md` makes the `plugins/` directory the single source of truth and says generic type-words ("plugin", "CGP", "Documentation") do not belong in a name. The directories already comply. `rootProject.name` did not.

## Commit 1 — finish the Voice Alerts and Rainbow Brackets renames

The earlier rename changed the directory names and `plugin.name`, and stopped there.

| Old | New |
|---|---|
| `com.example.beepy` | `org.appdevforall.voicealerts` |
| `Beepy` (class) | `VoiceAlertsPlugin` |
| `org.appdevforall.rainbowonthego` | `org.appdevforall.rainbowbrackets` |
| `RainbowOnTheGoPlugin` | `RainbowBracketsPlugin` |

Applied to `plugin.id`, `applicationId`, `namespace`, the Kotlin package directories, class names, `android:label`, `app_name`, proguard keep rules, both READMEs, both add-on HTML pages, and the Rainbow Brackets Tier 3 help page and tooltip text.

Also fixed: `RainbowBracketsPlugin.getTooltipCategory()` returned the hand-written `"plugin_rainbow_on_the_go"` instead of `"plugin_" + plugin.id`. Per CLAUDE.md that mismatch makes the tooltip render the literal `n/a`. It now derives from `PLUGIN_ID`.

## Commit 2 — derive `rootProject.name` for all 22 add-ons

```
code-suggestions-plugin -> code-suggestions
fluttertemplate         -> flutter-templates
GetAiModelsPlugin       -> get-ai-models
IconsRepository-Plugin  -> icons-repository
compose-preview         -> jetpack-compose-preview
ndk-installer-plugin    -> ndk-installer
sketch-to-ui-plugin     -> sketch-to-ui
speech-to-text-plugin   -> speech-to-text
vector-search-plugin    -> vector-search
```

Plus the places that quoted those stale names: README build instructions naming `.cgp` files the build never produced, `cd <old-name>` lines, dead `ai-core` links into sibling directories that no longer exist, and the Icons Repository display name in its manifest label, README heading and add-on page.

Left alone on purpose:
- Upstream GitHub URLs for the Icons Repository attribution keep the original repository name.
- Kotlin class names keep the `...Plugin` suffix. They are code identifiers, not the add-on's name, and 18 of 22 add-ons already use it.

## Breaking

`plugin.id` changes for Voice Alerts and Rainbow Brackets, so the Plugin Manager sees new add-ons. An existing install does not upgrade in place — it must be removed and reinstalled.

## Verification

- `addons check` passes. `check-toolchain.sh` passes.
- Clean `assemblePlugin` for Voice Alerts, Rainbow Brackets and Icons Repository. Packaged manifests confirmed with `aapt2 dump xmltree`:
  - `voice-alerts.cgp` — `package=org.appdevforall.voicealerts`, `plugin.main_class=org.appdevforall.voicealerts.VoiceAlertsPlugin`, label `Voice Alerts`, three WAVs and both icons present.
  - `rainbow-brackets.cgp` — `package=org.appdevforall.rainbowbrackets`, `plugin.main_class=org.appdevforall.rainbowbrackets.RainbowBracketsPlugin`, `assets/docs/index.html` and both icons present.
- **Not device-verified.** The tooltip-category fix in particular only shows up on a device long-press, so it needs an install before that part is trusted.

https://claude.ai/code/session_016aaKF7nPCSrLe7oZ5DTHLZ