### PR TITLE
Mark the two community add-ons as community

### DIFF
--- a/plugins/Flutter-Templates/addon.json
+++ b/plugins/Flutter-Templates/addon.json
@@ -1,15 +1,15 @@
 {
   "summary": "Adds five Flutter starter projects to the New Project screen.",
-  "description": "Installs Flutter project templates so you can start a Flutter app from the New Project screen instead of building the structure by hand.",
+  "description": "Installs Flutter project templates so you can start a Flutter app from the New Project screen instead of building the structure by hand. Contributed to Code On The Go by RJ Ali, from an original idea by Raju Kumar.",
   "tags": [
     "flutter",
     "templates",
     "dart"
   ],
-  "origin": "appdevforall",
+  "origin": "community",
   "license": "AGPL-3.0-or-later",
   "author": {
-    "name": "App Dev For All",
-    "url": "https://www.appdevforall.org"
+    "name": "RJ Ali",
+    "url": ""
   }
 }

--- a/plugins/Icons-Repository/addon.json
+++ b/plugins/Icons-Repository/addon.json
@@ -1,15 +1,15 @@
 {
   "summary": "Adds vector icons to a project from inside the editor.",
-  "description": "Browses a library of vector drawable icons and writes the one you pick straight into the project resources.",
+  "description": "Browses a library of vector drawable icons and writes the one you pick straight into the project resources. Contributed to Code On The Go by Omar Haidar.",
   "tags": [
     "icons",
     "resources",
     "design"
   ],
-  "origin": "appdevforall",
+  "origin": "community",
   "license": "AGPL-3.0-or-later",
   "author": {
-    "name": "App Dev For All",
-    "url": "https://www.appdevforall.org"
+    "name": "Omar Haidar",
+    "url": "https://github.com/omar-haidar"
   }
 }


### PR DESCRIPTION
## Why

Every `addon.json` claimed `origin: "appdevforall"` with App Dev For All as the author. Two consequences:

1. The gallery's **Origin** filter has a Community option that matched nothing.
2. Two outside contributors were credited to us on their own cards.

## What the evidence says

`appdevforall.org/plugins/` names the third-party contributions, and the repository agrees:

| Add-on | Contributor | In-repo evidence |
|---|---|---|
| Icons Repository | Omar Haidar | `README.md` "Credits" section, upstream `github.com/omar-haidar/IconsRepository-Plugin` |
| Flutter Templates | RJ Ali, from an idea by Raju Kumar | `README.md` "Credit" section, `Author: RJ Ali` byline on the add-on page |

The site also lists **Cotg-NDK by Arman King** as community, but that add-on is not in this repository.

Everything else carries App Dev for All attribution in-repo and no contributor name on the site, so the remaining 20 are unchanged.

## Changes

Both add-ons move to `origin: "community"` with the contributor as `author`, and the credit line moves into `description` so it shows on the card.

## Open questions

- `author.url` is empty for RJ Ali — the repository has only an email address, no public profile. Fill it in if he has a GitHub account.
- `plugins/Icons-Repository/README.md` states `**License:** (e.g., MIT, Apache 2.0)` — an unfilled template placeholder. `addon.json` claims `AGPL-3.0-or-later` for it. I left the claim alone rather than guess at a third party's license, but it needs confirming with Omar Haidar.

## Verification

`addons check` passes.

https://claude.ai/code/session_016aaKF7nPCSrLe7oZ5DTHLZ